### PR TITLE
Fix compilation issue.

### DIFF
--- a/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.cpp
+++ b/OMEdit/OMEditGUI/Modeling/LibraryTreeWidget.cpp
@@ -600,7 +600,7 @@ QVariant LibraryTreeItem::data(int column, int role) const
         case Qt::ToolTipRole:
           return mToolTip;
         case Qt::ForegroundRole:
-          return mIsSaved ? QVariant() : Qt::darkRed;
+          return mIsSaved ? QVariant() : QColor(Qt::darkRed);
         default:
           return QVariant();
       }


### PR DESCRIPTION
- QVariant(Qt::GlobalColor) constructor is private.
  Using QVariant(QColor) instead, as suggested in QVariant header.
