### PR TITLE
Remove superfluous "OpenModelica"

### DIFF
--- a/OMEdit/OMEditGUI/MainWindow.cpp
+++ b/OMEdit/OMEditGUI/MainWindow.cpp
@@ -3261,7 +3261,7 @@ AboutOMEditWidget::AboutOMEditWidget(MainWindow *pMainWindow)
   Label *pIntroLabel = new Label(Helper::applicationIntroText);
   pIntroLabel->setFont(QFont(Helper::systemFontInfo.family(), Helper::systemFontInfo.pointSize() + 3 + MAC_FONT_FACTOR));
   // OpenModelica compiler info
-  Label *pConnectedLabel = new Label(QString("Connected to OpenModelica ").append(Helper::OpenModelicaVersion));
+  Label *pConnectedLabel = new Label(QString("Connected to ").append(Helper::OpenModelicaVersion));
   pConnectedLabel->setFont(QFont(Helper::systemFontInfo.family(), Helper::systemFontInfo.pointSize() - 2 + MAC_FONT_FACTOR));
   // about text
   QString aboutText = QString("Copyright <b>Open Source Modelica Consortium (OSMC)</b>.<br />")


### PR DESCRIPTION
`Helper::OpenModelicaVersion = getVersion();` but
`getVersion()` gives something like
"OpenModelica 1.9.4~dev.beta1-35-g1e6dea7"

so OpenModelica appears twice in the display.
