### PR TITLE
attempt to fix Cpp under Windows when using gcc

### DIFF
--- a/OMEdit/OMEditGUI/Util/StringHandler.cpp
+++ b/OMEdit/OMEditGUI/Util/StringHandler.cpp
@@ -1478,7 +1478,7 @@ QProcessEnvironment StringHandler::simulationProcessEnvironment()
 {
   QProcessEnvironment environment = QProcessEnvironment::systemEnvironment();
   QString OMHOME = QString(Helper::OpenModelicaHome).replace("/", "\\");
-  QString OMHOMEBin = OMHOME + "\\bin;" + OMHOME + "\\lib\\omc\\msvc;" + OMHOME + "\\lib\\omc\\cpp\\msvc";
+  QString OMHOMEBin = OMHOME + "\\bin;" + OMHOME + "\\lib\\omc\\msvc;" + OMHOME + "\\lib\\omc\\cpp;" + OMHOME + "\\lib\\omc\\cpp\\msvc";
   environment.insert("PATH", OMHOMEBin + ";" + environment.value("PATH"));
   return environment;
 }


### PR DESCRIPTION
In OMEdit under Windows:

select Tools->Options->Simulation->Target Language: Cpp
select Tools->Options->Simulation->Target Compiler: gcc
open a model, e.g. Modelica.Blocks.Examples.Filter
simulate ->

This results in:

```
Process crashed
Simulation process failed. Exited with code -1073741515.
```

This is most likely because the path of the Cpp dll's is not set. It is:

$(omHome)\lib\omc\cpp

Should this path possibly be added to StringHandler::simulationEnvironment() in OMEdit/OMEdit/OMEditGUI/Util/StringHandler.cpp?
