### PR TITLE
Fixed bug in fetch interface function.

### DIFF
--- a/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
+++ b/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
@@ -406,6 +406,7 @@ void MetaModelEditor::addInterfacesData(QDomElement interfaces)
     QDomElement subModel = subModelList.at(i).toElement();
     QDomElement interfaceDataElement = interfaces.firstChildElement();
     while (!interfaceDataElement.isNull()) {
+      subModel = subModelList.at(i).toElement();
       if (subModel.attribute("Name").compare(interfaceDataElement.attribute("model")) == 0
           && !existInterfaceData(subModel.attribute("Name"), interfaceDataElement.attribute("name"))) {
         QDomElement interfacePoint = mXmlDocument.createElement("InterfacePoint");


### PR DESCRIPTION
For some reason the QDomElement lost its connection after calling
XmlDocument.toSTring(). Therefore, only the first interface for
each submodel was fetched.
