### PR TITLE
Some fixes to alignment of meta models

### DIFF
--- a/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
+++ b/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
@@ -434,6 +434,9 @@ void MetaModelEditor::addInterfacesData(QDomElement interfaces)
   QDomNodeList subModelList = mXmlDocument.elementsByTagName("SubModel");
   for (int i = 0 ; i < subModelList.size() ; i++) {
     QDomElement subModel = subModelList.at(i).toElement();
+    while(!subModel.firstChildElement("InterfacePoint").isNull()) { //First remove all existing interfaces!
+      subModel.removeChild(subModel.firstChildElement("InterfacePoint"));
+    }
     QDomElement interfaceDataElement = interfaces.firstChildElement();
     while (!interfaceDataElement.isNull()) {
       subModel = subModelList.at(i).toElement();

--- a/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
+++ b/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
@@ -820,7 +820,7 @@ void MetaModelEditor::alignInterfaces(QString fromInterface, QString toInterface
 inline bool MetaModelEditor::fuzzyCompare(double p1, double p2)
 {
   //! @todo What tolerance should be used? This is just a random number that seemed to work for some reason.
-  return (qAbs(p1 - p2) <= 0.001 * qMin(qAbs(p1), qAbs(p2)));
+  return (qAbs(p1 - p2) <= qMax(1e-5 * qMin(qAbs(p1), qAbs(p2)),1e-10));
 }
 
 /*!

--- a/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
+++ b/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
@@ -441,14 +441,14 @@ void MetaModelEditor::addInterfacesData(QDomElement interfaces)
         QDomElement interfacePoint;
         // update interface point
         if (existInterfaceData(subModel.attribute("Name"), interfaceDataElement)) {
-          interfacePoint = getInterfacePoint(subModel.attribute("Name"), interfaceDataElement.attribute("name"));
-          interfacePoint.setAttribute("Name", interfaceDataElement.attribute("name"));
+          interfacePoint = getInterfacePoint(subModel.attribute("Name"), interfaceDataElement.attribute("Name"));
+          interfacePoint.setAttribute("Name", interfaceDataElement.attribute("Name"));
           interfacePoint.setAttribute("Position", interfaceDataElement.attribute("Position"));
           interfacePoint.setAttribute("Angle321", interfaceDataElement.attribute("Angle321"));
           setPlainText(mXmlDocument.toString());
           // check if interface is aligned
           foreach (LineAnnotation* pConnectionLineAnnotation, mpModelWidget->getDiagramGraphicsView()->getConnectionsList()) {
-            QString interfaceName = QString("%1.%2").arg(subModel.attribute("Name")).arg(interfaceDataElement.attribute("name"));
+            QString interfaceName = QString("%1.%2").arg(subModel.attribute("Name")).arg(interfaceDataElement.attribute("Name"));
             if (pConnectionLineAnnotation->getStartComponentName().compare(interfaceName) == 0) {
               alignInterfaces(pConnectionLineAnnotation->getStartComponentName(), pConnectionLineAnnotation->getEndComponentName(), false);
             }

--- a/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
+++ b/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
@@ -441,14 +441,14 @@ void MetaModelEditor::addInterfacesData(QDomElement interfaces)
         QDomElement interfacePoint;
         // update interface point
         if (existInterfaceData(subModel.attribute("Name"), interfaceDataElement)) {
-          interfacePoint = getInterfacePoint(subModel.attribute("Name"), interfaceDataElement.attribute("Name"));
-          interfacePoint.setAttribute("Name", interfaceDataElement.attribute("Name"));
+          interfacePoint = getInterfacePoint(subModel.attribute("Name"), interfaceDataElement.attribute("name"));
+          interfacePoint.setAttribute("Name", interfaceDataElement.attribute("name"));
           interfacePoint.setAttribute("Position", interfaceDataElement.attribute("Position"));
           interfacePoint.setAttribute("Angle321", interfaceDataElement.attribute("Angle321"));
           setPlainText(mXmlDocument.toString());
           // check if interface is aligned
           foreach (LineAnnotation* pConnectionLineAnnotation, mpModelWidget->getDiagramGraphicsView()->getConnectionsList()) {
-            QString interfaceName = QString("%1.%2").arg(subModel.attribute("Name")).arg(interfaceDataElement.attribute("Name"));
+            QString interfaceName = QString("%1.%2").arg(subModel.attribute("Name")).arg(interfaceDataElement.attribute("name"));
             if (pConnectionLineAnnotation->getStartComponentName().compare(interfaceName) == 0) {
               alignInterfaces(pConnectionLineAnnotation->getStartComponentName(), pConnectionLineAnnotation->getEndComponentName(), false);
             }
@@ -458,14 +458,14 @@ void MetaModelEditor::addInterfacesData(QDomElement interfaces)
           }
         } else {  // insert interface point
           QDomElement interfacePoint = mXmlDocument.createElement("InterfacePoint");
-          interfacePoint.setAttribute("Name", interfaceDataElement.attribute("Name"));
+          interfacePoint.setAttribute("Name", interfaceDataElement.attribute("name"));
           interfacePoint.setAttribute("Position", interfaceDataElement.attribute("Position"));
           interfacePoint.setAttribute("Angle321", interfaceDataElement.attribute("Angle321"));
           subModel.appendChild(interfacePoint);
           setPlainText(mXmlDocument.toString());
           Component *pComponent = mpModelWidget->getDiagramGraphicsView()->getComponentObject(subModel.attribute("Name"));
           if (pComponent) {
-            pComponent->insertInterfacePoint(interfaceDataElement.attribute("Name"));
+            pComponent->insertInterfacePoint(interfaceDataElement.attribute("name"));
           }
         }
       }

--- a/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
+++ b/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
@@ -434,9 +434,6 @@ void MetaModelEditor::addInterfacesData(QDomElement interfaces)
   QDomNodeList subModelList = mXmlDocument.elementsByTagName("SubModel");
   for (int i = 0 ; i < subModelList.size() ; i++) {
     QDomElement subModel = subModelList.at(i).toElement();
-    while(!subModel.firstChildElement("InterfacePoint").isNull()) { //First remove all existing interfaces!
-      subModel.removeChild(subModel.firstChildElement("InterfacePoint"));
-    }
     QDomElement interfaceDataElement = interfaces.firstChildElement();
     while (!interfaceDataElement.isNull()) {
       subModel = subModelList.at(i).toElement();

--- a/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
+++ b/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
@@ -574,8 +574,8 @@ bool MetaModelEditor::getPositionAndRotationVectors(QString interfacePoint,
   QString x_c_r_x_str, x_c_phi_x_str;
   QString cg_x_phi_cg_str, cg_x_r_cg_str;
   QDomElement subModelElement = getSubModelElement(modelName);
-  cg_x_r_cg_str = subModelElement.attribute("Position");
-  cg_x_phi_cg_str = subModelElement.attribute("Angle321");
+  cg_x_r_cg_str = subModelElement.attribute("Position","0,0,0");
+  cg_x_phi_cg_str = subModelElement.attribute("Angle321","0,0,0");
   QDomElement interfaceElement = subModelElement.firstChildElement("InterfacePoint");
   while(!interfaceElement.isNull()) {
     if(interfaceElement.attribute("Name").compare(interfaceName) == 0) {
@@ -691,7 +691,7 @@ void MetaModelEditor::alignInterfaces(QString fromInterface, QString toInterface
 inline bool MetaModelEditor::fuzzyCompare(double p1, double p2)
 {
   //! @todo What tolerance should be used? This is just a random number that seemed to work for some reason.
-  return (qAbs(p1 - p2) <= 0.00001 * qMin(qAbs(p1), qAbs(p2)));
+  return (qAbs(p1 - p2) <= 0.001 * qMin(qAbs(p1), qAbs(p2)));
 }
 
 


### PR DESCRIPTION
Changes to fetch interface function
- Interfaces no longer existing in external model will be removed from meta model
- Connections to no longer existing interfaces will be removed

Changes to alignment
- Submodels without position and/or rotation are now assumed to be at 0,0,0 when aligning
- Fixed fuzzyEqual function so that it handles zero values
