### PR TITLE
Save FMI platform setting None, ticket:4070

### DIFF
--- a/OMEdit/OMEditGUI/MainWindow.cpp
+++ b/OMEdit/OMEditGUI/MainWindow.cpp
@@ -715,6 +715,9 @@ void MainWindow::exportModelFMU(LibraryTreeItem *pLibraryTreeItem)
   QString FMUName = mpOptionsDialog->getFMIPage()->getFMUNameTextBox()->text();
   QSettings *pSettings = Utilities::getApplicationSettings();
   QList<QString> platforms = pSettings->value("FMIExport/Platforms").toStringList();
+  int index = platforms.indexOf("none");
+  if (index > -1)
+    platforms.removeAt(index);
   if (mpOMCProxy->buildModelFMU(pLibraryTreeItem->getNameStructure(), version, type, FMUName, platforms)) {
     mpMessagesWidget->addGUIMessage(MessageItem(MessageItem::Modelica, "", false, 0, 0, 0, 0, GUIMessages::getMessage(GUIMessages::FMU_GENERATED)
                                                 .arg(FMUName.isEmpty() ? pLibraryTreeItem->getNameStructure() : FMUName)

--- a/OMEdit/OMEditGUI/Options/OptionsDialog.cpp
+++ b/OMEdit/OMEditGUI/Options/OptionsDialog.cpp
@@ -1047,9 +1047,7 @@ void OptionsDialog::saveFMISettings()
   // save platforms
   QStringList platforms;
   QString linking = mpFMIPage->getLinkingComboBox()->itemData(mpFMIPage->getLinkingComboBox()->currentIndex()).toString();
-  if (linking.compare("none") != 0) {
-    platforms.append(linking);
-  }
+  platforms.append(linking);
   int i = 0;
   while (QLayoutItem* pLayoutItem = mpFMIPage->getPlatformsGroupBox()->layout()->itemAt(i)) {
     if (dynamic_cast<QCheckBox*>(pLayoutItem->widget())) {


### PR DESCRIPTION
The change works as expected, i.e. one can disable the native FMI target.
