### PR TITLE
Keep Variables Browser if shown in Modeling Perspective

### DIFF
--- a/OMEdit/OMEditGUI/MainWindow.cpp
+++ b/OMEdit/OMEditGUI/MainWindow.cpp
@@ -225,6 +225,8 @@ MainWindow::MainWindow(QSplashScreen *pSplashScreen, bool debug, QWidget *parent
   mpVariablesDockWidget->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
   addDockWidget(Qt::RightDockWidgetArea, mpVariablesDockWidget);
   mpVariablesDockWidget->setWidget(mpVariablesWidget);
+  mShowVariablesWithModel = false;
+  mPreviousPerspective = -1;
   // set the corners for the dock widgets
   setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);
   setCorner(Qt::BottomLeftCorner, Qt::LeftDockWidgetArea);
@@ -2955,6 +2957,9 @@ void MainWindow::switchToWelcomePerspective()
   mpUndoAction->setEnabled(false);
   mpRedoAction->setEnabled(false);
   mpModelSwitcherToolButton->setEnabled(false);
+  if (mPreviousPerspective == 1) {
+    mShowVariablesWithModel =  mpVariablesDockWidget->isVisible();
+  }
   mpVariablesDockWidget->hide();
   mpStackFramesDockWidget->hide();
   mpBreakpointsDockWidget->hide();
@@ -2962,6 +2967,7 @@ void MainWindow::switchToWelcomePerspective()
   mpTargetOutputDockWidget->hide();
   mpGDBLoggerDockWidget->hide();
   mpPlotToolBar->setEnabled(false);
+  mPreviousPerspective = 0;
 }
 
 /*!
@@ -2972,19 +2978,25 @@ void MainWindow::switchToModelingPerspective()
 {
   mpCentralStackedWidget->setCurrentWidget(mpModelWidgetContainer);
   mpModelWidgetContainer->currentModelWidgetChanged(mpModelWidgetContainer->getCurrentMdiSubWindow());
-  mpVariablesDockWidget->hide();
-  mpPlotToolBar->setEnabled(false);
+  if (mShowVariablesWithModel) {
+    mpVariablesDockWidget->show();
+    mpPlotToolBar->setEnabled(true);
+  }
+  else {
+    mpVariablesDockWidget->hide();
+    mpPlotToolBar->setEnabled(false);
+  }
   // In case user has tabbed the dock widgets then make LibraryWidget active.
   QList<QDockWidget*> tabifiedDockWidgetsList = tabifiedDockWidgets(mpLibraryDockWidget);
   if (tabifiedDockWidgetsList.size() > 0) {
     tabifyDockWidget(tabifiedDockWidgetsList.at(0), mpLibraryDockWidget);
   }
-  mpVariablesDockWidget->hide();
   mpStackFramesDockWidget->hide();
   mpBreakpointsDockWidget->hide();
   mpLocalsDockWidget->hide();
   mpTargetOutputDockWidget->hide();
   mpGDBLoggerDockWidget->hide();
+  mPreviousPerspective = 1;
 }
 
 /*!
@@ -3012,6 +3024,9 @@ void MainWindow::switchToPlottingPerspective()
   if (mpPlotWindowContainer->subWindowList().size() == 0) {
     mpPlotWindowContainer->addPlotWindow(true);
   }
+  if (mPreviousPerspective == 1) {
+    mShowVariablesWithModel = mpVariablesDockWidget->isVisible();
+  }
   mpVariablesDockWidget->show();
   mpPlotToolBar->setEnabled(true);
   // In case user has tabbed the dock widgets then make VariablesWidget active.
@@ -3019,12 +3034,12 @@ void MainWindow::switchToPlottingPerspective()
   if (tabifiedDockWidgetsList.size() > 0) {
     tabifyDockWidget(tabifiedDockWidgetsList.at(0), mpVariablesDockWidget);
   }
-  mpVariablesDockWidget->show();
   mpStackFramesDockWidget->hide();
   mpBreakpointsDockWidget->hide();
   mpLocalsDockWidget->hide();
   mpTargetOutputDockWidget->hide();
   mpGDBLoggerDockWidget->hide();
+  mPreviousPerspective = 2;
 }
 
 /*!
@@ -3035,6 +3050,9 @@ void MainWindow::switchToAlgorithmicDebuggingPerspective()
 {
   mpCentralStackedWidget->setCurrentWidget(mpModelWidgetContainer);
   mpModelWidgetContainer->currentModelWidgetChanged(mpModelWidgetContainer->getCurrentMdiSubWindow());
+  if (mPreviousPerspective == 1) {
+    mShowVariablesWithModel = mpVariablesDockWidget->isVisible();
+  }
   mpVariablesDockWidget->hide();
   mpPlotToolBar->setEnabled(false);
   // In case user has tabbed the dock widgets then make LibraryWidget active.
@@ -3047,6 +3065,7 @@ void MainWindow::switchToAlgorithmicDebuggingPerspective()
   mpLocalsDockWidget->show();
   mpTargetOutputDockWidget->show();
   mpGDBLoggerDockWidget->show();
+  mPreviousPerspective = 3;
 }
 
 /*!

--- a/OMEdit/OMEditGUI/MainWindow.cpp
+++ b/OMEdit/OMEditGUI/MainWindow.cpp
@@ -225,7 +225,7 @@ MainWindow::MainWindow(QSplashScreen *pSplashScreen, bool debug, QWidget *parent
   mpVariablesDockWidget->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
   addDockWidget(Qt::RightDockWidgetArea, mpVariablesDockWidget);
   mpVariablesDockWidget->setWidget(mpVariablesWidget);
-  mShowVariablesWithModel = false;
+  mShowVariablesWithModel = true;
   mPreviousPerspective = -1;
   // set the corners for the dock widgets
   setCorner(Qt::TopLeftCorner, Qt::LeftDockWidgetArea);

--- a/OMEdit/OMEditGUI/MainWindow.h
+++ b/OMEdit/OMEditGUI/MainWindow.h
@@ -134,6 +134,7 @@ public:
   Label* getPointerXPositionLabel() {return mpPointerXPositionLabel;}
   Label* getPointerYPositionLabel() {return mpPointerYPositionLabel;}
   QTabBar* getPerspectiveTabBar() {return mpPerspectiveTabbar;}
+  QToolBar* getPlotToolBar() {return mpPlotToolBar;}
   QTimer* getAutoSaveTimer() {return mpAutoSaveTimer;}
   QAction* getSaveAction() {return mpSaveAction;}
   QAction* getSaveAsAction() {return mpSaveAsAction;}
@@ -210,6 +211,8 @@ private:
   bool mDebug;
   OMCProxy *mpOMCProxy;
   bool mExitApplicationStatus;
+  bool mShowVariablesWithModel;
+  int mPreviousPerspective;
   OptionsDialog *mpOptionsDialog;
   MessagesWidget *mpMessagesWidget;
   QDockWidget *mpMessagesDockWidget;

--- a/OMEdit/OMEditGUI/Simulation/SimulationDialog.cpp
+++ b/OMEdit/OMEditGUI/Simulation/SimulationDialog.cpp
@@ -1270,7 +1270,15 @@ void SimulationDialog::simulationProcessFinished(SimulationOptions simulationOpt
     // close the simulation result file.
     pOMCProxy->closeSimulationResultFile();
     if (list.size() > 0) {
-      mpMainWindow->getPerspectiveTabBar()->setCurrentIndex(2);
+      if (mpMainWindow->getVariablesDockWidget()->isVisible()
+          && !mpLaunchAnimationCheckBox->isChecked()) {
+        // stay in current perspective and enable re-simulation
+        mpMainWindow->getPlotToolBar()->setEnabled(true);
+      }
+      else {
+        // switch to plotting perspective
+        mpMainWindow->getPerspectiveTabBar()->setCurrentIndex(2);
+      }
       // if simulated with animation then open the animation directly.
       if (mpLaunchAnimationCheckBox->isChecked()) {
         mpMainWindow->getPlotWindowContainer()->addAnimationWindow();


### PR DESCRIPTION
This enables edit/simulate/re-simulate cycles directly
in the modeling perspective -- useful for steady-state models and
maybe also in the future if the model diagram will be animated.

This pull request does not change the given behavior unless the Variables Browser is explicitly shown in the modeling perspecitve.
