### PR TITLE
Shorten display string of enumeration values, ticket:4084

### DIFF
--- a/OMEdit/OMEditGUI/Component/Component.cpp
+++ b/OMEdit/OMEditGUI/Component/Component.cpp
@@ -1055,6 +1055,15 @@ QString Component::getParameterDisplayString(QString parameterName)
   if (displayString.isEmpty()) {
     displayString = getParameterDisplayStringFromExtendsParameters(parameterName);
   }
+  /* Short enumeration value, ModelicaSpec 3.3, section 18.6.5.5, ticket:4084 */
+  /* Note: for now just look for dots in non-numbers to avoid lookup of type */
+  bool ok = false;
+  displayString.toDouble(&ok);
+  if (!ok) {
+    int lastDot = displayString.lastIndexOf(".");
+    if (lastDot >= 0)
+      displayString = displayString.right(displayString.length() - lastDot - 1);
+  }
   return displayString;
 }
 

--- a/OMEdit/OMEditGUI/Component/Component.h
+++ b/OMEdit/OMEditGUI/Component/Component.h
@@ -278,7 +278,8 @@ private:
   void setOriginAndExtents();
   void updateConnections();
   QString getParameterDisplayStringFromExtendsModifiers(QString parameterName);
-  QString getParameterDisplayStringFromExtendsParameters(QString parameterName);
+  QString getParameterDisplayStringFromExtendsParameters(QString parameterName, QString modifierString);
+  bool checkEnumerationDisplayString(QString &displayString, const QString &typeName);
   void updateToolTip();
 signals:
   void added();


### PR DESCRIPTION
This change seems to do the job. Didn't find an example that would be broken.

The change could have been introduced into TextAnnotation::updateTextStringHelper. It appears though that Component::getParameterDisplayString is just made for these kind of displays. This is why the change is introduced there. Moreover, the type information required for a more rigorous solution would be available in Component::getParameterDisplayString.
