### PR TITLE
Issues

### DIFF
--- a/OMEdit/OMEditGUI/Component/ComponentProperties.cpp
+++ b/OMEdit/OMEditGUI/Component/ComponentProperties.cpp
@@ -251,8 +251,8 @@ QString Parameter::getFixedState()
 }
 
 /*!
- * \brief Parameter::getUnitFromDerivedClass
- * Returns the unit value by reading the derived classes.
+ * \brief Parameter::getModifierValueFromDerivedClass
+ * Returns the modifier value by reading the derived classes.
  * \param pComponent
  * \param modifierName
  * \return the modifier value.
@@ -272,14 +272,13 @@ QString Parameter::getModifierValueFromDerivedClass(Component *pComponent, QStri
      * pInheritedComponent->getLibraryTreeItem()->getNameStructure() to get the correct name of inherited class.
      * Also don't just return after reading from first inherited class. Check recursively.
      */
-//    if (!pOMCProxy->isBuiltinType(pInheritedComponent->getComponentInfo()->getClassName())) {
-//      return pOMCProxy->getDerivedClassModifierValue(pInheritedComponent->getComponentInfo()->getClassName(), modifierName);
-//    }
-//    return getModifierValueFromDerivedClass(pInheritedComponent, modifierName);
     if (pInheritedComponent->getLibraryTreeItem() &&
         !pOMCProxy->isBuiltinType(pInheritedComponent->getLibraryTreeItem()->getNameStructure())) {
       modifierValue = pOMCProxy->getDerivedClassModifierValue(pInheritedComponent->getLibraryTreeItem()->getNameStructure(),
                                                               modifierName);
+      if (modifierValue.isEmpty()) {
+        modifierValue = getModifierValueFromDerivedClass(pInheritedComponent, modifierName);
+      }
       if (!modifierValue.isEmpty()) {
         return modifierValue;
       }

--- a/OMEdit/OMEditGUI/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditGUI/Plotting/VariablesWidget.cpp
@@ -512,6 +512,10 @@ void VariablesTreeModel::insertVariablesItems(QString fileName, QString filePath
       QString str = plotVariable;
       str.chop((str.lastIndexOf("der(")/4)+1);
       variables = StringHandler::makeVariableParts(str.mid(str.lastIndexOf("der(") + 4));
+    } else if (plotVariable.startsWith("previous(")) {
+      QString str = plotVariable;
+      str.chop((str.lastIndexOf("previous(")/9)+1);
+      variables = StringHandler::makeVariableParts(str.mid(str.lastIndexOf("previous(") + 9));
     } else {
       variables = StringHandler::makeVariableParts(plotVariable);
     }
@@ -525,6 +529,8 @@ void VariablesTreeModel::insertVariablesItems(QString fileName, QString filePath
       /* if last item */
       if (variables.size() == count && plotVariable.startsWith("der(")) {
         findVariable = parentVariable.isEmpty() ? fileName + ".der(" + variable + ")" : fileName + "." + parentVariable + ".der(" + variable + ")";
+      } else if (variables.size() == count && plotVariable.startsWith("previous(")) {
+        findVariable = parentVariable.isEmpty() ? fileName + ".previous(" + variable + ")" : fileName + "." + parentVariable + ".previous(" + variable + ")";
       } else {
         findVariable = parentVariable.isEmpty() ? fileName + "." + variable : fileName + "." + parentVariable + "." + variable;
       }
@@ -550,6 +556,8 @@ void VariablesTreeModel::insertVariablesItems(QString fileName, QString filePath
       /* if last item */
       if (variables.size() == count && plotVariable.startsWith("der(")) {
         variableData << filePath << fileName << fileName + "." + plotVariable << "der(" + variable + ")";
+      } else if (variables.size() == count && plotVariable.startsWith("previous(")) {
+        variableData << filePath << fileName << fileName + "." + plotVariable << "previous(" + variable + ")";
       } else {
         variableData << filePath << fileName << pParentVariablesTreeItem->getVariableName() + "." + variable << variable;
       }

--- a/OMEdit/OMEditGUI/Simulation/SimulationDialog.cpp
+++ b/OMEdit/OMEditGUI/Simulation/SimulationDialog.cpp
@@ -111,6 +111,28 @@ void SimulationDialog::directSimulate(LibraryTreeItem *pLibraryTreeItem, bool la
 }
 
 /*!
+  A scroll area with vertical bar and adjustment of width
+  See: https://forum.qt.io/topic/13374/solved-qscrollarea-vertical-scroll-only
+  */
+class VerticalScrollArea : public QScrollArea
+{
+public:
+  VerticalScrollArea()
+  {
+    setWidgetResizable(true);
+    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+  }
+
+  virtual bool eventFilter(QObject *o, QEvent *e)
+  {
+    if (o && o == widget() && e->type() == QEvent::Resize)
+      setMinimumWidth(widget()->minimumSizeHint().width() + verticalScrollBar()->width());
+    return QScrollArea::eventFilter(o, e);
+  }
+};
+
+/*!
   Creates all the controls and set their layout.
   */
 void SimulationDialog::setUpForm()
@@ -124,6 +146,11 @@ void SimulationDialog::setUpForm()
   mpSimulationTabWidget = new QTabWidget;
   // General Tab
   mpGeneralTab = new QWidget;
+  // General Tab scroll area
+  mpGeneralTabScrollArea = new VerticalScrollArea;
+  mpGeneralTabScrollArea->setFrameShape(QFrame::NoFrame);
+  mpGeneralTabScrollArea->setBackgroundRole(QPalette::Base);
+  mpGeneralTabScrollArea->setWidget(mpGeneralTab);
   // Simulation Interval
   mpSimulationIntervalGroupBox = new QGroupBox(tr("Simulation Interval"));
   mpStartTimeLabel = new Label(tr("Start Time:"));
@@ -270,7 +297,7 @@ void SimulationDialog::setUpForm()
   pGeneralTabLayout->addWidget(mpLaunchAnimationCheckBox, 7, 0, 1, 3);
   mpGeneralTab->setLayout(pGeneralTabLayout);
   // add General Tab to Simulation TabWidget
-  mpSimulationTabWidget->addTab(mpGeneralTab, Helper::general);
+  mpSimulationTabWidget->addTab(mpGeneralTabScrollArea, Helper::general);
   // Output Tab
   mpOutputTab = new QWidget;
   // Output Format

--- a/OMEdit/OMEditGUI/Simulation/SimulationDialog.h
+++ b/OMEdit/OMEditGUI/Simulation/SimulationDialog.h
@@ -83,6 +83,7 @@ private:
   QTabWidget *mpSimulationTabWidget;
   // General Tab
   QWidget *mpGeneralTab;
+  QScrollArea *mpGeneralTabScrollArea;
   QGroupBox *mpSimulationIntervalGroupBox;
   Label *mpStartTimeLabel;
   QLineEdit *mpStartTimeTextBox;


### PR DESCRIPTION
The first commit adds a vertical scrollbar to the General tab of the Simulation dialog. Otherwise it may exceed the size of laptop screens. The horizontal scrollbar is disabled and the width is adjusted instead.

The second commit fixes unit lookup (the code did not do it even though the comments say so). See the following example and open the parameter dialog for component1 in DisplayUnit.Test:

```
package DisplayUnit
  type Voltage = Modelica.SIunits.Voltage(displayUnit = "kV");
  model Component
    parameter Voltage V;
  end Component;
  model Test
    Component component1(V = 110000)  annotation(Placement(visible = true, transformation(origin = {0, 0}, extent = {{-44, -44}, {44, 44}}, rotation = 0)));
  end Test;
end DisplayUnit;
```
