### PR TITLE
DynamicSelect for text annotations

### DIFF
--- a/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.cpp
@@ -372,6 +372,7 @@ void ShapeAnnotation::setDefaults(ShapeAnnotation *pShapeAnnotation)
   mClassFileName = pShapeAnnotation->mClassFileName;
   mImageSource = pShapeAnnotation->mImageSource;
   mImage = pShapeAnnotation->mImage;
+  mDynamicSelect = pShapeAnnotation->mDynamicSelect;
 }
 
 /*!

--- a/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.h
+++ b/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.h
@@ -254,6 +254,7 @@ protected:
   QString mClassFileName; /* Used to find the bitmap relative locations. */
   QString mImageSource;
   QImage mImage;
+  QStringList mDynamicSelect; /* list of DynamicSelect arguments */
   QList<CornerItem*> mCornerItemsList;
   virtual void contextMenuEvent(QGraphicsSceneContextMenuEvent *pEvent);
   virtual QVariant itemChange(GraphicsItemChange change, const QVariant &value);

--- a/OMEdit/OMEditGUI/Component/ComponentProperties.cpp
+++ b/OMEdit/OMEditGUI/Component/ComponentProperties.cpp
@@ -1134,6 +1134,8 @@ void ComponentParameters::updateComponentParameters()
                                                                              newComponentExtendsModifiersMap);
     mpComponent->getGraphicsView()->getModelWidget()->getUndoStack()->push(pUpdateComponentParametersCommand);
     mpComponent->getGraphicsView()->getModelWidget()->updateModelText();
+    // remove possible dynamic results to see the new static values
+    mpComponent->getGraphicsView()->getModelWidget()->removeDynamicResults();
   }
   accept();
 }

--- a/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.h
+++ b/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.h
@@ -369,6 +369,8 @@ public:
   void updateModelText();
   void updateModelicaTextManually(QString contents);
   void updateUndoRedoActions();
+  void updateDynamicResults(QString resultFileName);
+  QString getResultFileName() {return mResultFileName;}
 private:
   ModelWidgetContainer *mpModelWidgetContainer;
   LibraryTreeItem *mpLibraryTreeItem;
@@ -400,6 +402,7 @@ private:
   QList<LibraryTreeItem*> mInheritedClassesList;
   QList<ComponentInfo*> mComponentsList;
   QStringList mComponentsAnnotationsList;
+  QString mResultFileName;
 
   void getModelInheritedClasses();
   void drawModelInheritedClassShapes(ModelWidget *pModelWidget, StringHandler::ViewType viewType);
@@ -427,6 +430,7 @@ public slots:
   bool metaModelEditorTextChanged();
   void handleCanUndoChanged(bool canUndo);
   void handleCanRedoChanged(bool canRedo);
+  void removeDynamicResults(QString resultFileName = "");
 protected:
   virtual void closeEvent(QCloseEvent *event);
 };
@@ -439,6 +443,7 @@ public:
   ModelWidgetContainer(MainWindow *pParent);
   void addModelWidget(ModelWidget *pModelWidget, bool checkPreferedView = true);
   ModelWidget* getCurrentModelWidget();
+  ModelWidget* getModelWidget(const QString &className);
   QMdiSubWindow* getCurrentMdiSubWindow();
   QMdiSubWindow* getMdiSubWindow(ModelWidget *pModelWidget);
   void setPreviousViewType(StringHandler::ViewType viewType) {mPreviousViewType = viewType;}

--- a/OMEdit/OMEditGUI/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditGUI/Plotting/VariablesWidget.cpp
@@ -239,6 +239,31 @@ VariablesTreeItem* VariablesTreeItem::rootParent()
   return pVariablesTreeItem1;
 }
 
+/*!
+ * \brief VariablesTreeItem::getValue
+ * Returns the value in the desired unit or
+ * an empty value in case of conversion error.
+ */
+QVariant VariablesTreeItem::getValue(QString unit, OMCProxy *pOMCProxy)
+{
+  QString value = "";
+  if (mPreviousUnit.compare(unit) == 0) {
+    value = mValue;
+  }
+  else {
+    OMCInterface::convertUnits_res convertUnit = pOMCProxy->convertUnits(mPreviousUnit, unit);
+    if (convertUnit.unitsCompatible) {
+      bool ok = false;
+      qreal realValue = mValue.toDouble(&ok);
+      if (ok) {
+        realValue = Utilities::convertUnit(realValue, convertUnit.offset, convertUnit.scaleFactor);
+        value = QString::number(realValue);
+      }
+    }
+  }
+  return value;
+}
+
 VariablesTreeModel::VariablesTreeModel(VariablesTreeView *pVariablesTreeView)
   : QAbstractItemModel(pVariablesTreeView)
 {
@@ -894,6 +919,23 @@ void VariablesWidget::insertVariablesItemsToTree(QString fileName, QString fileP
   /* In order to improve the response time of insertVariablesItems function we should clear the filter and collapse all the items. */
   mpVariableTreeProxyModel->setFilterRegExp(QRegExp(""));
   mpVariablesTreeView->collapseAll();
+  /* Show results in model diagram if it is present in ModelWidgetContainer
+     and if switch to plotting perspective is disabled */
+  ModelWidget *pModelWidget = NULL;
+  if (!mpMainWindow->getOptionsDialog()->getSimulationPage()->getSwitchToPlottingPerspectiveCheckBox()->isChecked()) {
+    pModelWidget = mpMainWindow->getModelWidgetContainer()->getModelWidget(simulationOptions.getClassName());
+  }
+  if (pModelWidget != NULL) {
+    if (simulationOptions.isReSimulate() && pModelWidget->getResultFileName().isEmpty()) {
+      /* skip update of model view if the model has changed */
+      pModelWidget = NULL;
+    }
+    else {
+      /* prevent update during removeVariableTreeItem
+         because the model will be updated below anyway */
+      pModelWidget->updateDynamicResults("");
+    }
+  }
   /* Remove the simulation result if we already had it in tree */
   bool variableItemDeleted = mpVariablesTreeModel->removeVariableTreeItem(fileName);
   /* add the plot variables */
@@ -901,6 +943,10 @@ void VariablesWidget::insertVariablesItemsToTree(QString fileName, QString fileP
   /* update the plot variables tree */
   if (variableItemDeleted) {
     variablesUpdated();
+  }
+  /* update the model widget */
+  if (pModelWidget != NULL) {
+    pModelWidget->updateDynamicResults(fileName);
   }
   mpVariablesTreeView->setSortingEnabled(true);
   mpVariablesTreeView->sortByColumn(0, Qt::AscendingOrder);
@@ -1023,20 +1069,11 @@ void VariablesWidget::readVariablesAndUpdateXML(VariablesTreeItem *pVariablesTre
   for (int i = 0 ; i < pVariablesTreeItem->getChildren().size() ; i++) {
     VariablesTreeItem *pChildVariablesTreeItem = pVariablesTreeItem->child(i);
     if (pChildVariablesTreeItem->isEditable() && pChildVariablesTreeItem->isValueChanged()) {
-      QString value = pChildVariablesTreeItem->data(1, Qt::DisplayRole).toString();
+      //QString value = pChildVariablesTreeItem->data(1, Qt::DisplayRole).toString();
       /* Ticket #2250, 4031
        * We need to convert the value to base unit since the values stored in init xml are always in base unit.
        */
-      if (pChildVariablesTreeItem->getUnit().compare(pChildVariablesTreeItem->getDisplayUnit()) != 0) {
-        OMCInterface::convertUnits_res convertUnit = mpMainWindow->getOMCProxy()->convertUnits(pChildVariablesTreeItem->getDisplayUnit(),
-                                                                                               pChildVariablesTreeItem->getUnit());
-        if (convertUnit.unitsCompatible) {
-          bool ok = true;
-          qreal realValue = value.toDouble(&ok);
-          realValue = Utilities::convertUnit(realValue, convertUnit.offset, convertUnit.scaleFactor);
-          value = QString::number(realValue);
-        }
-      }
+      QString value = pChildVariablesTreeItem->getValue(pChildVariablesTreeItem->getUnit(), mpMainWindow->getOMCProxy()).toString();
       QString variableToFind = pChildVariablesTreeItem->getVariableName();
       variableToFind.remove(QRegExp(outputFileName + "."));
       QHash<QString, QString> hash;
@@ -1195,18 +1232,8 @@ void VariablesWidget::plotVariables(const QModelIndex &index, qreal curveThickne
          * Update the value of Variables Browser display unit according to the display unit of already plotted curve.
          */
         pVariablesTreeItem->setData(3, pPlotCurve->getDisplayUnit(), Qt::EditRole);
-        OMCInterface::convertUnits_res convertUnit = mpMainWindow->getOMCProxy()->convertUnits(pVariablesTreeItem->getPreviousUnit(),
-                                                                                               pVariablesTreeItem->getDisplayUnit());
-        if (convertUnit.unitsCompatible) {
-          /* update value */
-          QVariant stringValue = pVariablesTreeItem->data(1, Qt::EditRole);
-          bool ok = true;
-          qreal realValue = stringValue.toDouble(&ok);
-          if (ok) {
-            realValue = Utilities::convertUnit(realValue, convertUnit.offset, convertUnit.scaleFactor);
-            pVariablesTreeItem->setData(1, QString::number(realValue), Qt::EditRole);
-          }
-        }
+        QString value = pVariablesTreeItem->getValue(pVariablesTreeItem->getDisplayUnit(), mpMainWindow->getOMCProxy()).toString();
+        pVariablesTreeItem->setData(1, value, Qt::EditRole);
         if (pPlotCurve && pVariablesTreeItem->getUnit().compare(pVariablesTreeItem->getDisplayUnit()) != 0) {
           OMCInterface::convertUnits_res convertUnit = mpMainWindow->getOMCProxy()->convertUnits(pVariablesTreeItem->getUnit(),
                                                                                                  pVariablesTreeItem->getDisplayUnit());

--- a/OMEdit/OMEditGUI/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditGUI/Plotting/VariablesWidget.cpp
@@ -726,8 +726,9 @@ void VariablesTreeModel::getVariableInformation(ModelicaMatReader *pMatReader, Q
   QHash<QString, QString> hash = mScalarVariablesList.value(variableToFind);
   if (hash["name"].compare(variableToFind) == 0) {
     *changeAble = (hash["isValueChangeable"].compare("true") == 0) ? true : false;
-    if (*changeAble) {
-      *value = hash["start"];
+    QString start = hash["start"];
+    if (*changeAble && !start.isEmpty()) {
+      *value = start;
     } else { /* if the variable is not a tunable parameter then read the final value of the variable. Only mat result files are supported. */
       if ((pMatReader->file != NULL) && strcmp(pMatReader->fileName, "")) {
         *value = "";

--- a/OMEdit/OMEditGUI/Plotting/VariablesWidget.h
+++ b/OMEdit/OMEditGUI/Plotting/VariablesWidget.h
@@ -73,6 +73,7 @@ public:
   int row() const;
   VariablesTreeItem* parent();
   VariablesTreeItem* rootParent();
+  QVariant getValue(QString unit, OMCProxy *pOMCProxy);
 private:
   QList<VariablesTreeItem*> mChildren;
   VariablesTreeItem *mpParentVariablesTreeItem;


### PR DESCRIPTION
PR #41 was generously deleted by Lena and Martin. This is an enhanced version that implements DynamicSelect for text annotations according to the Modelica spec.

Currently restricted to one String argument accessing one variable, e.g.
   DynamicSelect("%level_start", String(level, significantDigits = 2)
(see Modelica.Fluid.Examples.Tanks.ThreeTanks).

Relying on OMC passing the DynamicSelect arguments
(see https://github.com/OpenModelica/OMCompiler/pull/1170/commits)

The ThreeTanks example shows the values of the tank levels at the end of the simulation -- if the Variables Browser had a time slider, then one could replay the simulation ...
