### PR TITLE
Implement DynamicSelect for visible, ticket:3675

### DIFF
--- a/OMEdit/OMEditGUI/Annotations/BitmapAnnotation.cpp
+++ b/OMEdit/OMEditGUI/Annotations/BitmapAnnotation.cpp
@@ -121,7 +121,7 @@ void BitmapAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem *
 {
   Q_UNUSED(option);
   Q_UNUSED(widget);
-  if (mVisible)
+  if (mVisible || !mDynamicVisible.isEmpty())
     drawBitmapAnnotaion(painter);
 }
 

--- a/OMEdit/OMEditGUI/Annotations/BitmapAnnotation.cpp
+++ b/OMEdit/OMEditGUI/Annotations/BitmapAnnotation.cpp
@@ -53,6 +53,7 @@ BitmapAnnotation::BitmapAnnotation(ShapeAnnotation *pShapeAnnotation, Component 
   : ShapeAnnotation(pParent), mpComponent(pParent)
 {
   updateShape(pShapeAnnotation);
+  initUpdateVisible(); // DynamicSelect for visible attribute
   setPos(mOrigin);
   setRotation(mRotation);
   connect(pShapeAnnotation, SIGNAL(updateReferenceShapes()), pShapeAnnotation, SIGNAL(changed()));

--- a/OMEdit/OMEditGUI/Annotations/EllipseAnnotation.cpp
+++ b/OMEdit/OMEditGUI/Annotations/EllipseAnnotation.cpp
@@ -126,8 +126,7 @@ void EllipseAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem 
 {
   Q_UNUSED(option);
   Q_UNUSED(widget);
-  if (mVisible)
-  {
+  if (mVisible || !mDynamicVisible.isEmpty()) {
     drawEllipseAnnotaion(painter);
   }
 }

--- a/OMEdit/OMEditGUI/Annotations/EllipseAnnotation.cpp
+++ b/OMEdit/OMEditGUI/Annotations/EllipseAnnotation.cpp
@@ -52,6 +52,7 @@ EllipseAnnotation::EllipseAnnotation(ShapeAnnotation *pShapeAnnotation, Componen
   : ShapeAnnotation(pParent)
 {
   updateShape(pShapeAnnotation);
+  initUpdateVisible(); // DynamicSelect for visible attribute
   setPos(mOrigin);
   setRotation(mRotation);
   connect(pShapeAnnotation, SIGNAL(updateReferenceShapes()), pShapeAnnotation, SIGNAL(changed()));

--- a/OMEdit/OMEditGUI/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditGUI/Annotations/LineAnnotation.cpp
@@ -58,6 +58,7 @@ LineAnnotation::LineAnnotation(ShapeAnnotation *pShapeAnnotation, Component *pPa
   : ShapeAnnotation(pParent)
 {
   updateShape(pShapeAnnotation);
+  initUpdateVisible(); // DynamicSelect for visible attribute
   setLineType(LineAnnotation::ComponentType);
   setStartComponent(0);
   setEndComponent(0);

--- a/OMEdit/OMEditGUI/Annotations/LineAnnotation.cpp
+++ b/OMEdit/OMEditGUI/Annotations/LineAnnotation.cpp
@@ -291,7 +291,7 @@ void LineAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
 {
   Q_UNUSED(option);
   Q_UNUSED(widget);
-  if (mVisible) {
+  if (mVisible || !mDynamicVisible.isEmpty()) {
     drawLineAnnotaion(painter);
   }
 }

--- a/OMEdit/OMEditGUI/Annotations/PolygonAnnotation.cpp
+++ b/OMEdit/OMEditGUI/Annotations/PolygonAnnotation.cpp
@@ -158,7 +158,7 @@ void PolygonAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem 
 {
   Q_UNUSED(option);
   Q_UNUSED(widget);
-  if (mVisible) {
+  if (mVisible || !mDynamicVisible.isEmpty()) {
     drawPolygonAnnotaion(painter);
   }
 }

--- a/OMEdit/OMEditGUI/Annotations/PolygonAnnotation.cpp
+++ b/OMEdit/OMEditGUI/Annotations/PolygonAnnotation.cpp
@@ -52,6 +52,7 @@ PolygonAnnotation::PolygonAnnotation(ShapeAnnotation *pShapeAnnotation, Componen
   : ShapeAnnotation(pParent)
 {
   updateShape(pShapeAnnotation);
+  initUpdateVisible(); // DynamicSelect for visible attribute
   setPos(mOrigin);
   setRotation(mRotation);
   connect(pShapeAnnotation, SIGNAL(updateReferenceShapes()), pShapeAnnotation, SIGNAL(changed()));

--- a/OMEdit/OMEditGUI/Annotations/RectangleAnnotation.cpp
+++ b/OMEdit/OMEditGUI/Annotations/RectangleAnnotation.cpp
@@ -52,6 +52,7 @@ RectangleAnnotation::RectangleAnnotation(ShapeAnnotation *pShapeAnnotation, Comp
   : ShapeAnnotation(pParent)
 {
   updateShape(pShapeAnnotation);
+  initUpdateVisible(); // DynamicSelect for visible attribute
   setPos(mOrigin);
   setRotation(mRotation);
   connect(pShapeAnnotation, SIGNAL(updateReferenceShapes()), pShapeAnnotation, SIGNAL(changed()));

--- a/OMEdit/OMEditGUI/Annotations/RectangleAnnotation.cpp
+++ b/OMEdit/OMEditGUI/Annotations/RectangleAnnotation.cpp
@@ -133,8 +133,9 @@ void RectangleAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsIte
 {
   Q_UNUSED(option);
   Q_UNUSED(widget);
-  if (mVisible)
+  if (mVisible || !mDynamicVisible.isEmpty()) {
     drawRectangleAnnotaion(painter);
+  }
 }
 
 void RectangleAnnotation::drawRectangleAnnotaion(QPainter *painter)

--- a/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.cpp
+++ b/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.cpp
@@ -987,6 +987,7 @@ void ShapeAnnotation::initUpdateVisible()
 {
   if (mpParentComponent) {
     if (!mDynamicVisible.isEmpty()) {
+      updateVisible();
       connect(mpParentComponent, SIGNAL(displayTextChanged()), SLOT(updateVisible()), Qt::UniqueConnection);
     }
   }

--- a/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.h
+++ b/OMEdit/OMEditGUI/Annotations/ShapeAnnotation.h
@@ -71,6 +71,7 @@ protected:
   bool mVisible;
   QPointF mOrigin;
   qreal mRotation;
+  QString mDynamicVisible; /* variable for visible attribute */
 };
 
 class FilledShape
@@ -176,6 +177,7 @@ public:
   QString getImageSource();
   void setImage(QImage image);
   QImage getImage();
+  QVariant getDynamicValue(QString name);
   void applyRotation(qreal angle);
   void adjustPointsWithOrigin();
   void adjustExtentsWithOrigin();
@@ -230,6 +232,7 @@ public slots:
   void referenceShapeAdded();
   void referenceShapeChanged();
   void referenceShapeDeleted();
+  void updateVisible();
 protected:
   GraphicsView *mpGraphicsView;
   Component *mpParentComponent;
@@ -254,8 +257,9 @@ protected:
   QString mClassFileName; /* Used to find the bitmap relative locations. */
   QString mImageSource;
   QImage mImage;
-  QStringList mDynamicSelect; /* list of DynamicSelect arguments */
   QList<CornerItem*> mCornerItemsList;
+  QList<QVariant> mDynamicTextString; /* list of String() arguments */
+  void initUpdateVisible();
   virtual void contextMenuEvent(QGraphicsSceneContextMenuEvent *pEvent);
   virtual QVariant itemChange(GraphicsItemChange change, const QVariant &value);
 };

--- a/OMEdit/OMEditGUI/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEditGUI/Annotations/TextAnnotation.cpp
@@ -34,7 +34,6 @@
 
 #include "TextAnnotation.h"
 #include "Commands.h"
-#include "VariablesWidget.h"
 
 /*!
  * \class TextAnnotation
@@ -64,6 +63,7 @@ TextAnnotation::TextAnnotation(ShapeAnnotation *pShapeAnnotation, Component *pPa
   : ShapeAnnotation(pParent), mpComponent(pParent)
 {
   updateShape(pShapeAnnotation);
+  initUpdateVisible(); // DynamicSelect for visible attribute
   initUpdateTextString();
   setPos(mOrigin);
   setRotation(mRotation);
@@ -126,9 +126,13 @@ void TextAnnotation::parseShapeAnnotation(QString annotation)
   // 10th item of the list contains the textString.
   if (list.at(9).startsWith("{")) {
     // DynamicSelect
-    mDynamicSelect = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(9)));
-    if (mDynamicSelect.count() >= 1)
-      mOriginalTextString = StringHandler::removeFirstLastQuotes(mDynamicSelect.at(0));
+    QStringList args = StringHandler::getStrings(StringHandler::removeFirstLastCurlBrackets(list.at(9)));
+    if (args.count() > 0)
+      mOriginalTextString = StringHandler::removeFirstLastQuotes(args.at(0));
+    if (args.count() > 1)
+      mDynamicTextString << args.at(1);  // variable name
+    if (args.count() > 2)
+      mDynamicTextString << args.at(2);  // significantDigits
   }
   else {
     mOriginalTextString = StringHandler::removeFirstLastQuotes(list.at(9));
@@ -429,7 +433,7 @@ void TextAnnotation::updateShape(ShapeAnnotation *pShapeAnnotation)
 void TextAnnotation::initUpdateTextString()
 {
   if (mpComponent) {
-    if (mOriginalTextString.contains("%") || mDynamicSelect.count() >= 2) {
+    if (mOriginalTextString.contains("%") || mDynamicTextString.count() > 0) {
       updateTextString();
       connect(mpComponent, SIGNAL(displayTextChanged()), SLOT(updateTextString()), Qt::UniqueConnection);
     }
@@ -469,6 +473,24 @@ void TextAnnotation::updateTextStringHelper(QRegExp regExp)
  */
 void TextAnnotation::updateTextString()
 {
+  /* optional DynamicSelect of textString attribute */
+  QVariant dynamicValue; // isNull() per default
+  if (mDynamicTextString.count() > 0) {
+    dynamicValue = getDynamicValue(mDynamicTextString.at(0).toString());
+  }
+  if (!dynamicValue.isNull()) {
+    mTextString = dynamicValue.toString();
+    if (mTextString.isEmpty()) {
+      /* use variable name as default value if result not found */
+      mTextString = mDynamicTextString.at(0).toString();
+    }
+    else if (mDynamicTextString.count() > 1) {
+      int digits = mDynamicTextString.at(1).toInt();
+      mTextString = QString::number(mTextString.toDouble(), 'g', digits);
+    }
+    return;
+  }
+  /* alternatively use model provided value */
   /* From Modelica Spec 32revision2,
    * There are a number of common macros that can be used in the text, and they should be replaced when displaying
    * the text as follows:
@@ -479,24 +501,6 @@ void TextAnnotation::updateTextString()
    * - %name replaced by the name of the component (i.e. the identifier for it in in the enclosing class).
    * - %class replaced by the name of the class.
    */
-  // first check for available results and DynamicSelect
-  ModelWidget *pModelWidget = mpComponent->getGraphicsView()->getModelWidget();
-  if (!pModelWidget->getResultFileName().isEmpty() && mDynamicSelect.count() >= 2) {
-    MainWindow *pMainWindow = pModelWidget->getModelWidgetContainer()->getMainWindow();
-    VariablesTreeModel *pVariablesTreeModel = pMainWindow->getVariablesWidget()->getVariablesTreeModel();
-    VariablesTreeItem *pVariablesTreeItem = pVariablesTreeModel->findVariablesTreeItem(pModelWidget->getResultFileName() + "." + mpComponent->getComponentInfo()->getName() + "." + mDynamicSelect.at(1), pVariablesTreeModel->getRootVariablesTreeItem());
-    if (pVariablesTreeItem != NULL) {
-      mTextString = pVariablesTreeItem->getValue(pVariablesTreeItem->getUnit(), pMainWindow->getOMCProxy()).toString();
-      if (mDynamicSelect.count() >= 3) {
-        int digits = mDynamicSelect.at(2).toInt();
-        mTextString = QString::number(mTextString.toDouble(), 'g', digits);
-      }
-    }
-    else
-      mTextString = mDynamicSelect.at(1); // default value if result not found
-    return;
-  }
-  // alternatively use model value
   mTextString = mOriginalTextString;
   if (!mTextString.contains("%")) {
     return;

--- a/OMEdit/OMEditGUI/Annotations/TextAnnotation.cpp
+++ b/OMEdit/OMEditGUI/Annotations/TextAnnotation.cpp
@@ -221,7 +221,7 @@ void TextAnnotation::paint(QPainter *painter, const QStyleOptionGraphicsItem *op
   } else if (mpComponent && mpComponent->getGraphicsView()->isRenderingLibraryPixmap()) {
     return;
   }
-  if (mVisible) {
+  if (mVisible || !mDynamicVisible.isEmpty()) {
     drawTextAnnotaion(painter);
   }
 }


### PR DESCRIPTION
This small addition enables a lot of dynamic graphics because each item can be shown conditionally.

The following example shows a rectangle and uses red color for negative values.

```
package IconWithValues
  model Component
    parameter Real x;
    Real y = sin(x);
    Boolean neg = y < 0;
    Boolean pos = not neg;
    annotation(Icon(graphics = {
      Rectangle(origin = {0, 0}, extent = {{-95, 95}, {95, -95}},
                visible = DynamicSelect(false, neg)),
      Text(origin = {-55, 35}, extent = {{-35, 15}, {50, -30}},
        textString = "x = "),
      Text(origin = {-55, 35}, extent = {{50, 15}, {150, -30}},
        textString = DynamicSelect("x", String(x))),
      Text(origin = {-55, -30}, extent = {{-35, 15}, {150, -30}},
        textString = DynamicSelect("%y",  String(y, significantDigits = 3)),
        visible = DynamicSelect(true, pos)),
      Text(origin = {-55, -30}, extent = {{-35, 15}, {150, -30}},
        textString = DynamicSelect("%y",  String(y, significantDigits = 3)),
        visible = DynamicSelect(false, neg), lineColor = {255, 0, 0})},
      coordinateSystem(initialScale = 0.1)));
  end Component;
  model Test
    Component component1(x = 5)
      annotation(Placement(visible = true,
        transformation(origin = {0, 0}, extent = {{-45, -45}, {45, 45}})));
  end Test;
end IconWithValues;
```

Relies on OMCompiler PR 1178 (Static.elabBuiltinDynamicSelect keeps DynamicSelect for visible attribute, provided it has no expressions).
