### PR TITLE
Revert "Fix states in Variables Browser"

### DIFF
--- a/OMEdit/OMEditGUI/Plotting/VariablesWidget.cpp
+++ b/OMEdit/OMEditGUI/Plotting/VariablesWidget.cpp
@@ -726,9 +726,8 @@ void VariablesTreeModel::getVariableInformation(ModelicaMatReader *pMatReader, Q
   QHash<QString, QString> hash = mScalarVariablesList.value(variableToFind);
   if (hash["name"].compare(variableToFind) == 0) {
     *changeAble = (hash["isValueChangeable"].compare("true") == 0) ? true : false;
-    QString start = hash["start"];
-    if (*changeAble && !start.isEmpty()) {
-      *value = start;
+    if (*changeAble) {
+      *value = hash["start"];
     } else { /* if the variable is not a tunable parameter then read the final value of the variable. Only mat result files are supported. */
       if ((pMatReader->file != NULL) && strcmp(pMatReader->fileName, "")) {
         *value = "";


### PR DESCRIPTION
This reverts commit 9ac8442981a730c0115e2f70ff5a277060f1d8ab.
It is fixed in OMCompiler now, see
"Only mark states as changeable if the start attribute is constant"
https://github.com/OpenModelica/OMCompiler/commit/95bc48164d3a12bde4f0fc1d0f4aeeb36f663439