### PR TITLE
Add missing include in PlotWindowContainer.h to fix build error

### DIFF
--- a/OMEdit/OMEditGUI/Plotting/PlotWindowContainer.h
+++ b/OMEdit/OMEditGUI/Plotting/PlotWindowContainer.h
@@ -41,6 +41,7 @@
 
 #include "MainWindow.h"
 #include "OMPlot.h"
+#include "Utilities.h"
 
 class MainWindow;
 class AnimationWindow;


### PR DESCRIPTION
Building OMEdit master branch gives the following compile error:

```
./Plotting/PlotWindowContainer.h:48:36: error: unknown class name 'MdiArea'; did you mean 'QMdiArea'?
class PlotWindowContainer : public MdiArea
```

"Utilities.h" should be included to make the class `MdiArea` known.
