### PR TITLE
Use 1e-6 as default tolerance value

### DIFF
--- a/OMEdit/OMEditGUI/OMC/OMCProxy.h
+++ b/OMEdit/OMEditGUI/OMC/OMCProxy.h
@@ -193,7 +193,7 @@ public:
   bool ngspicetoModelica(QString fileName);
   QString checkAllModelsRecursive(QString className);
   bool isExperiment(QString className);
-  OMCInterface::getSimulationOptions_res getSimulationOptions(QString className, double defaultTolerance = 1e-4);
+  OMCInterface::getSimulationOptions_res getSimulationOptions(QString className, double defaultTolerance = 1e-6);
   bool buildModelFMU(QString className, double version, QString type, QString fileNamePrefix, QList<QString> platforms);
   bool translateModelXML(QString className);
   QString importFMU(QString fmuName, QString outputDirectory, int logLevel, bool debugLogging, bool generateInputConnectors, bool generateOutputConnectors);


### PR DESCRIPTION
It seems that `OMEdit` and `omc` are using different tolerances for simulation by default.

@adeas31 Can you please review this changes? I try to fix lochel/PNlib#26.