### PR TITLE
fix pipe-shape and xml file name assembly

### DIFF
--- a/OMEdit/OMEditGUI/Animation/AnimationUtil.h
+++ b/OMEdit/OMEditGUI/Animation/AnimationUtil.h
@@ -89,8 +89,9 @@ inline bool isCSV(const std::string& fileIn){
  */
 inline std::string assembleXMLFileName(const std::string& modelFile, const std::string& path){
   QString fileName(modelFile.c_str());
-  QRegExp fileTypeRegExp("(\\.fmu|\\.mat|\\.csv|_res.mat|_res.csv)");
-  fileName.remove(fileTypeRegExp);
+  QRegExp fileTypeRegExp("(_res.mat|_res.csv|\\.fmu)");
+  int pos = fileName.lastIndexOf(fileTypeRegExp);
+  fileName = fileName.left(pos);
   // Construct XML file name
   std::string xmlFileName = path + fileName.toStdString() + "_visual.xml";
   return xmlFileName;

--- a/OMEdit/OMEditGUI/Animation/AnimationUtil.h
+++ b/OMEdit/OMEditGUI/Animation/AnimationUtil.h
@@ -38,6 +38,7 @@
 
 #include <QString>
 #include <QRegExp>
+#include <QFileInfo>
 
 #include <sys/stat.h>
 #include <string>
@@ -88,12 +89,18 @@ inline bool isCSV(const std::string& fileIn){
  * constructs the name of the corresponding xml file
  */
 inline std::string assembleXMLFileName(const std::string& modelFile, const std::string& path){
-  QString fileName(modelFile.c_str());
-  QRegExp fileTypeRegExp("(_res.mat|_res.csv|\\.fmu)");
-  int pos = fileName.lastIndexOf(fileTypeRegExp);
-  fileName = fileName.left(pos);
+  QFileInfo fi(modelFile.c_str());
+  QString suf = fi.suffix();
+  if(!(suf.compare("mat") || suf.compare("csv") || suf.compare("fmu")) )
+  {
+	  std::cout<<"This file extension is not supported."<<std::endl;
+  }
+  QString base = fi.completeBaseName();
+  if (base.endsWith("_res")){
+	  base.remove(base.length()-4,4);
+  }
   // Construct XML file name
-  std::string xmlFileName = path + fileName.toStdString() + "_visual.xml";
+  std::string xmlFileName = path + base.toStdString() + "_visual.xml";
   return xmlFileName;
 }
 

--- a/OMEdit/OMEditGUI/Animation/Visualizer.cpp
+++ b/OMEdit/OMEditGUI/Animation/Visualizer.cpp
@@ -663,7 +663,7 @@ rAndT rotateModelica2OSG(osg::Vec3f r, osg::Vec3f r_shape, osg::Matrix3 T, osg::
     res._r = res._r + r;
     res._T = Mat3mulMat3(T0, T);
   }
-  else if ((type == "spring")||(type == "pipecylinder")||(type == "cone"))
+  else if ((type == "spring")||(type == "pipecylinder")||(type == "cone") || (type == "pipe"))
   {
     res._r = V3mulMat3(r_shape, T);
     res._r = res._r + r;


### PR DESCRIPTION
I dont know whats the difference between a pipe and a pipecylinder but they exist both.

If the model would name BasicExample.matilda.mo the filename parsing would fail again. Strictly rely on result files of type *_res.*