### PR TITLE
Fix compilation error on OS X

### DIFF
--- a/OMEdit/OMEditGUI/main.cpp
+++ b/OMEdit/OMEditGUI/main.cpp
@@ -46,6 +46,8 @@
  * - Abhinn Kothari
  */
 
+#include <locale.h>
+
 #include "MainWindow.h"
 #include "Util/Helper.h"
 #include "CrashReport/CrashReportDialog.h"


### PR DESCRIPTION
Fixes:
```
main.cpp:262:13: error: use of undeclared identifier 'LC_NUMERIC'
  setlocale(LC_NUMERIC, "C");
```