### PR TITLE
Made it possible to fetch interface data for a single external model

### DIFF
--- a/OMEdit/OMEditGUI/Component/Component.cpp
+++ b/OMEdit/OMEditGUI/Component/Component.cpp
@@ -1458,6 +1458,11 @@ void Component::createActions()
   mpParametersAction = new QAction(Helper::parameters, mpGraphicsView);
   mpParametersAction->setStatusTip(tr("Shows the component parameters"));
   connect(mpParametersAction, SIGNAL(triggered()), SLOT(showParameters()));
+  // Fetch interfaces action
+  mpFetchInterfaceDataAction = new QAction(Helper::fetchInterfaceData, mpGraphicsView);
+  mpFetchInterfaceDataAction->setStatusTip(tr("Fetch interface data for this external model"));
+  connect(mpFetchInterfaceDataAction, SIGNAL(triggered()), SLOT(fetchInterfaceData()));
+  // Todo: Connect /robbr
   // Attributes Action
   mpAttributesAction = new QAction(Helper::attributes, mpGraphicsView);
   mpAttributesAction->setStatusTip(tr("Shows the component attributes"));
@@ -2371,6 +2376,11 @@ void Component::showAttributes()
   pComponentAttributes->exec();
 }
 
+void Component::fetchInterfaceData()
+{
+    MainWindow::instance()->fetchInterfaceData(mpGraphicsView->getModelWidget()->getLibraryTreeItem(), this->getName());
+}
+
 /*!
  * \brief Component::openClass
  * Slot that opens up the component Modelica class in a new tab/window.
@@ -2471,6 +2481,7 @@ void Component::contextMenuEvent(QGraphicsSceneContextMenuEvent *event)
         menu.addAction(mpGraphicsView->getFlipVerticalAction());
         break;
       case LibraryTreeItem::MetaModel:
+        menu.addAction(pComponent->getFetchInterfaceDataAction());
         menu.addAction(pComponent->getSubModelAttributesAction());
         break;
     }

--- a/OMEdit/OMEditGUI/Component/Component.h
+++ b/OMEdit/OMEditGUI/Component/Component.h
@@ -197,6 +197,7 @@ public:
   CoOrdinateSystem getCoOrdinateSystem() const;
   OriginItem* getOriginItem() {return mpOriginItem;}
   QAction* getParametersAction() {return mpParametersAction;}
+  QAction* getFetchInterfaceDataAction() {return mpFetchInterfaceDataAction;}
   QAction* getAttributesAction() {return mpAttributesAction;}
   QAction* getOpenClassAction() {return mpOpenClassAction;}
   QAction* getViewDocumentationAction() {return mpViewDocumentationAction;}
@@ -253,6 +254,7 @@ private:
   RectangleAnnotation *mpDefaultComponentRectangle;
   TextAnnotation *mpDefaultComponentText;
   QAction *mpParametersAction;
+  QAction *mpFetchInterfaceDataAction;
   QAction *mpAttributesAction;
   QAction *mpOpenClassAction;
   QAction *mpViewDocumentationAction;
@@ -339,6 +341,7 @@ public slots:
   void moveCtrlRight();
   void showParameters();
   void showAttributes();
+  void fetchInterfaceData();
   void openClass();
   void viewDocumentation();
   void showSubModelAttributes();

--- a/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
+++ b/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
@@ -537,7 +537,7 @@ QString MetaModelEditor::getSimulationStopTime()
  * Adds the InterfacePoint tag to SubModel.
  * \param interfaces
  */
-void MetaModelEditor::addInterfacesData(QDomElement interfaces)
+void MetaModelEditor::addInterfacesData(QDomElement interfaces, QString singleModel)
 {
   QDomNodeList subModelList = mXmlDocument.elementsByTagName("SubModel");
   for (int i = 0 ; i < subModelList.size() ; i++) {
@@ -545,7 +545,8 @@ void MetaModelEditor::addInterfacesData(QDomElement interfaces)
     QDomElement interfaceDataElement = interfaces.firstChildElement();
     while (!interfaceDataElement.isNull()) {
       subModel = subModelList.at(i).toElement();
-      if (subModel.attribute("Name").compare(interfaceDataElement.attribute("model")) == 0) {
+      if (subModel.attribute("Name").compare(interfaceDataElement.attribute("model")) == 0 &&
+          (subModel.attribute("Name") == singleModel || singleModel.isEmpty())) {
         QDomElement interfacePoint;
         // update interface point
         if (existInterfaceData(subModel.attribute("Name"), interfaceDataElement)) {
@@ -592,6 +593,9 @@ void MetaModelEditor::addInterfacesData(QDomElement interfaces)
 
     //Now remove all elements in sub model that does not exist in fetched interfaces (i.e. has been externally removed)
     subModel = subModelList.at(i).toElement();
+    if(subModel.attribute("Name") != singleModel && !singleModel.isEmpty()){
+        continue;   //Ignore other models if single model is specified
+    }
     Component *pComponent = mpModelWidget->getDiagramGraphicsView()->getComponentObject(subModel.attribute("Name"));
     QDomElement subModelInterfaceDataElement = subModel.firstChildElement("InterfacePoint");
     while (!subModelInterfaceDataElement.isNull()) {

--- a/OMEdit/OMEditGUI/Editors/MetaModelEditor.h
+++ b/OMEdit/OMEditGUI/Editors/MetaModelEditor.h
@@ -86,7 +86,7 @@ public:
   bool isSimulationParams();
   QString getSimulationStartTime();
   QString getSimulationStopTime();
-  void addInterfacesData(QDomElement interfaces);
+  void addInterfacesData(QDomElement interfaces, QString singleModel=QString());
   bool interfacesAligned(QString interface1, QString interface2);
   bool deleteSubModel(QString name);
   bool deleteConnection(QString startComponentName, QString endComponentName);

--- a/OMEdit/OMEditGUI/MainWindow.cpp
+++ b/OMEdit/OMEditGUI/MainWindow.cpp
@@ -825,7 +825,7 @@ void MainWindow::exportModelFigaro(LibraryTreeItem *pLibraryTreeItem)
  * \param pLibraryTreeItem
  * Fetches the interface data for TLM co-simulation.
  */
-void MainWindow::fetchInterfaceData(LibraryTreeItem *pLibraryTreeItem)
+void MainWindow::fetchInterfaceData(LibraryTreeItem *pLibraryTreeItem, QString singleModel)
 {
   /* if MetaModel text is changed manually by user then validate it before fetaching the interface data. */
   if (pLibraryTreeItem->getModelWidget()) {
@@ -838,7 +838,7 @@ void MainWindow::fetchInterfaceData(LibraryTreeItem *pLibraryTreeItem)
     QMessageBox::information(this, QString(Helper::applicationName).append(" - ").append(Helper::information), message, Helper::ok);
   } else {
     if (pLibraryTreeItem->isSaved()) {
-      fetchInterfaceDataHelper(pLibraryTreeItem);
+      fetchInterfaceDataHelper(pLibraryTreeItem, singleModel);
     } else {
       QMessageBox *pMessageBox = new QMessageBox(this);
       pMessageBox->setWindowTitle(QString(Helper::applicationName).append(" - ").append(Helper::question));
@@ -851,7 +851,7 @@ void MainWindow::fetchInterfaceData(LibraryTreeItem *pLibraryTreeItem)
       switch (answer) {
         case QMessageBox::Yes:
           if (mpLibraryWidget->saveLibraryTreeItem(pLibraryTreeItem)) {
-            fetchInterfaceDataHelper(pLibraryTreeItem);
+            fetchInterfaceDataHelper(pLibraryTreeItem, singleModel);
           }
           break;
         case QMessageBox::No:
@@ -2230,6 +2230,9 @@ void MainWindow::readInterfaceData(LibraryTreeItem *pLibraryTreeItem)
     return;
   }
 
+  FetchInterfaceDataDialog *pDialog = qobject_cast<FetchInterfaceDataDialog*>(sender());
+  QString singleModel = pDialog->getSingleModel();
+
   QFileInfo fileInfo(pLibraryTreeItem->getFileName());
   QFile file(fileInfo.absoluteDir().absolutePath()+ "/interfaceData.xml");
   if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
@@ -2247,7 +2250,7 @@ void MainWindow::readInterfaceData(LibraryTreeItem *pLibraryTreeItem)
       mpLibraryWidget->getLibraryTreeModel()->showModelWidget(pLibraryTreeItem);
     }
     MetaModelEditor *pMetaModelEditor = dynamic_cast<MetaModelEditor*>(pLibraryTreeItem->getModelWidget()->getEditor());
-    pMetaModelEditor->addInterfacesData(interfaces);
+    pMetaModelEditor->addInterfacesData(interfaces, singleModel);
   }
 }
 
@@ -3210,7 +3213,7 @@ void MainWindow::tileSubWindows(QMdiArea *pMdiArea, bool horizontally)
  * \param pLibraryTreeItem
  * Helper function for fetching the interface data.
  */
-void MainWindow::fetchInterfaceDataHelper(LibraryTreeItem *pLibraryTreeItem)
+void MainWindow::fetchInterfaceDataHelper(LibraryTreeItem *pLibraryTreeItem, QString singleModel)
 {
   /* if Modelica text is changed manually by user then validate it before saving. */
   if (pLibraryTreeItem->getModelWidget()) {
@@ -3218,7 +3221,7 @@ void MainWindow::fetchInterfaceDataHelper(LibraryTreeItem *pLibraryTreeItem)
       return;
     }
   }
-  FetchInterfaceDataDialog *pFetchInterfaceDataDialog = new FetchInterfaceDataDialog(pLibraryTreeItem, this);
+  FetchInterfaceDataDialog *pFetchInterfaceDataDialog = new FetchInterfaceDataDialog(pLibraryTreeItem, singleModel, this);
   connect(pFetchInterfaceDataDialog, SIGNAL(readInterfaceData(LibraryTreeItem*)), SLOT(readInterfaceData(LibraryTreeItem*)));
   pFetchInterfaceDataDialog->exec();
 }

--- a/OMEdit/OMEditGUI/MainWindow.h
+++ b/OMEdit/OMEditGUI/MainWindow.h
@@ -178,7 +178,7 @@ public:
   void exportModelFMU(LibraryTreeItem *pLibraryTreeItem);
   void exportModelXML(LibraryTreeItem *pLibraryTreeItem);
   void exportModelFigaro(LibraryTreeItem *pLibraryTreeItem);
-  void fetchInterfaceData(LibraryTreeItem *pLibraryTreeItem);
+  void fetchInterfaceData(LibraryTreeItem *pLibraryTreeItem, QString singleModel=QString());
   void TLMSimulate(LibraryTreeItem *pLibraryTreeItem);
   void exportModelToOMNotebook(LibraryTreeItem *pLibraryTreeItem);
   void createOMNotebookTitleCell(LibraryTreeItem *pLibraryTreeItem, QDomDocument xmlDocument, QDomElement domElement);
@@ -446,7 +446,7 @@ private:
   void switchToAlgorithmicDebuggingPerspective();
   void closeAllWindowsButThis(QMdiArea *pMdiArea);
   void tileSubWindows(QMdiArea *pMdiArea, bool horizontally);
-  void fetchInterfaceDataHelper(LibraryTreeItem *pLibraryTreeItem);
+  void fetchInterfaceDataHelper(LibraryTreeItem *pLibraryTreeItem, QString singleModel=QString());
 protected:
   virtual void dragEnterEvent(QDragEnterEvent *event);
   virtual void dragMoveEvent(QDragMoveEvent *event);

--- a/OMEdit/OMEditGUI/TLM/FetchInterfaceDataDialog.cpp
+++ b/OMEdit/OMEditGUI/TLM/FetchInterfaceDataDialog.cpp
@@ -46,7 +46,7 @@
  * \param pLibraryTreeItem
  * \param pParent
  */
-FetchInterfaceDataDialog::FetchInterfaceDataDialog(LibraryTreeItem *pLibraryTreeItem, QWidget *pParent)
+FetchInterfaceDataDialog::FetchInterfaceDataDialog(LibraryTreeItem *pLibraryTreeItem, QString singleModel, QWidget *pParent)
   : QDialog(pParent), mpLibraryTreeItem(pLibraryTreeItem)
 {
   setWindowTitle(QString(Helper::applicationName).append(" - ").append(tr("Fetch Interface Data")).append(" - ")
@@ -54,6 +54,7 @@ FetchInterfaceDataDialog::FetchInterfaceDataDialog(LibraryTreeItem *pLibraryTree
   setAttribute(Qt::WA_DeleteOnClose);
   setMinimumWidth(550);
   mpLibraryTreeItem = pLibraryTreeItem;
+  mSingleModel = singleModel;
   // progress
   mpProgressLabel = new Label;
   mpProgressLabel->setTextFormat(Qt::RichText);

--- a/OMEdit/OMEditGUI/TLM/FetchInterfaceDataDialog.h
+++ b/OMEdit/OMEditGUI/TLM/FetchInterfaceDataDialog.h
@@ -49,10 +49,12 @@ class FetchInterfaceDataDialog : public QDialog
 {
   Q_OBJECT
 public:
-  FetchInterfaceDataDialog(LibraryTreeItem *pLibraryTreeItem, QWidget *pParent = 0);
+  FetchInterfaceDataDialog(LibraryTreeItem *pLibraryTreeItem, QString singleModel = QString(), QWidget *pParent = 0);
   LibraryTreeItem* getLibraryTreeItem() {return mpLibraryTreeItem;}
+  QString getSingleModel() {return mSingleModel;}
 private:
   LibraryTreeItem *mpLibraryTreeItem;
+  QString mSingleModel;
   Label *mpProgressLabel;
   QProgressBar *mpProgressBar;
   QPushButton *mpCancelButton;

--- a/OMEdit/OMEditGUI/TLM/FetchInterfaceDataThread.cpp
+++ b/OMEdit/OMEditGUI/TLM/FetchInterfaceDataThread.cpp
@@ -58,7 +58,12 @@ void FetchInterfaceDataThread::run()
   connect(mpManagerProcess, SIGNAL(readyReadStandardError()), SLOT(readManagerStandardError()));
   connect(mpManagerProcess, SIGNAL(finished(int,QProcess::ExitStatus)), SLOT(managerProcessFinished(int,QProcess::ExitStatus)));
   QStringList args;
-  args << "-r" << fileInfo.absoluteFilePath();
+  args << "-r";
+  QString singleModel = mpFetchInterfaceDataDialog->getSingleModel();
+  if(!singleModel.isEmpty()) {
+      args << "-s" << singleModel;
+  }
+  args << fileInfo.absoluteFilePath();
   TLMPage *pTLMPage = OptionsDialog::instance()->getTLMPage();
   QProcessEnvironment environment;
 #ifdef WIN32


### PR DESCRIPTION
- Added right-click action for fetching interface data for single components.
- Made it possible to fetch data for a single external model
- Made sure other interfaces are not affected when fetching for a single model.

(it requires the TLMPlugin compiled from the TLMInterface1D branch from the SVN repo)