### PR TITLE
Fixed folder names for composite xmodels and added support for more startup scripts

### DIFF
--- a/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
+++ b/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
@@ -244,6 +244,9 @@ void MetaModelEditor::setMetaModelName(QString name)
 bool MetaModelEditor::addSubModel(QString name, QString modelFile, QString startCommand, QString visible, QString origin,
                                   QString extent, QString rotation)
 {
+  Component* pComp = mpModelWidget->getDiagramGraphicsView()->getComponentObject(name);
+  name = name.remove(".");
+  pComp->getComponentInfo()->setName(name);
   QDomElement subModels = getSubModelsElement();
   if (!subModels.isNull()) {
     QDomElement subModel = mXmlDocument.createElement("SubModel");

--- a/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
@@ -262,7 +262,7 @@ bool GraphicsView::addComponent(QString className, QPointF position)
         pComponentInfo->setStartCommand("StartTLMBeast");
       } else if (fileInfo.suffix().compare("hmf") == 0) {
         pComponentInfo->setStartCommand("StartTLMHopsan");
-      } else if (fileInfo.suffix().compare("in") == 0) {
+      } else if (fileInfo.suffix().compare("fmu") == 0) {
         pComponentInfo->setStartCommand("StartTLMFmiWrapper");
       } else if (fileInfo.suffix().compare("slx") == 0) {
         pComponentInfo->setStartCommand("StartTLMSimulink");

--- a/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
@@ -260,6 +260,12 @@ bool GraphicsView::addComponent(QString className, QPointF position)
         pComponentInfo->setStartCommand("StartTLMOpenModelica");
       } else if (fileInfo.suffix().compare("in") == 0) {
         pComponentInfo->setStartCommand("StartTLMBeast");
+      } else if (fileInfo.suffix().compare("hmf") == 0) {
+        pComponentInfo->setStartCommand("StartTLMHopsan");
+      } else if (fileInfo.suffix().compare("in") == 0) {
+        pComponentInfo->setStartCommand("StartTLMFmiWrapper");
+      } else if (fileInfo.suffix().compare("slx") == 0) {
+        pComponentInfo->setStartCommand("StartTLMSimulink");
       } else {
         pComponentInfo->setStartCommand("");
       }


### PR DESCRIPTION
Folders are not allowed to have dots in their names since everything after first dot is interpreted as a file extension. This is solved by removing all dots from component names directly when they are added to the metamodel.

Also added generation of startup scripts for all tools known to be working.