### PR TITLE
Added support for submodel parameters in composite models

### DIFF
--- a/OMEdit/OMEditGUI/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditGUI/Animation/AbstractAnimationWindow.cpp
@@ -72,7 +72,8 @@ AbstractAnimationWindow::AbstractAnimationWindow(QWidget *pParent)
     mpSpeedComboBox(nullptr),
     mpPerspectiveDropDownBox(nullptr),
     mpRotateCameraLeftAction(nullptr),
-    mpRotateCameraRightAction(nullptr)
+    mpRotateCameraRightAction(nullptr),
+    mCameraInitialized(false)
 {
   // to distinguish this widget as a subwindow among the plotwindows
   setObjectName(QString("animationWidget"));
@@ -99,7 +100,7 @@ AbstractAnimationWindow::AbstractAnimationWindow(QWidget *pParent)
  * \brief AbstractAnimationWindow::openAnimationFile
  * \param fileName
  */
-void AbstractAnimationWindow::openAnimationFile(QString fileName)
+void AbstractAnimationWindow::openAnimationFile(QString fileName, bool stashCamera)
 {
   std::string file = fileName.toStdString();
   if (file.compare("")) {
@@ -128,6 +129,11 @@ void AbstractAnimationWindow::openAnimationFile(QString fileName)
       } else {
         mpPerspectiveDropDownBox->setCurrentIndex(1);
         cameraPositionSide();
+      }
+
+      if(stashCamera && !mCameraInitialized) {         // mCameraInitialized is used to make sure the view is never stashed
+        mCameraInitialized = true;      // before the camera is initialized the first time
+        stashView();
       }
     }
   }
@@ -212,6 +218,19 @@ void AbstractAnimationWindow::clearView()
     mpViewerWidget->getSceneView()->setSceneData(0);
     mpViewerWidget->update();
   }
+}
+
+void AbstractAnimationWindow::stashView()
+{
+  if(!mCameraInitialized) return;
+  mStashedViewMatrix = mpViewerWidget->getSceneView()->getCameraManipulator()->getMatrix();
+}
+
+void AbstractAnimationWindow::popView()
+{
+    if(!mCameraInitialized) return;
+    mpViewerWidget->getSceneView()->getCameraManipulator()->setByMatrix(mStashedViewMatrix);
+    mpViewerWidget->update();
 }
 
 /*!

--- a/OMEdit/OMEditGUI/Animation/AbstractAnimationWindow.h
+++ b/OMEdit/OMEditGUI/Animation/AbstractAnimationWindow.h
@@ -52,9 +52,11 @@ class AbstractAnimationWindow : public QMainWindow
   Q_OBJECT
 public:
   AbstractAnimationWindow(QWidget *pParent);
-  void openAnimationFile(QString fileName);
+  void openAnimationFile(QString fileName, bool stashCamera=false);
   virtual void createActions();
   void clearView();
+  void stashView();
+  void popView();
 private:
   bool loadVisualization();
 protected:
@@ -78,6 +80,8 @@ protected:
   QComboBox *mpPerspectiveDropDownBox;
   QAction *mpRotateCameraLeftAction;
   QAction *mpRotateCameraRightAction;
+  osg::Matrixd mStashedViewMatrix;
+  bool mCameraInitialized;
 
   void resetCamera();
   void cameraPositionIsometric();

--- a/OMEdit/OMEditGUI/Component/ComponentProperties.h
+++ b/OMEdit/OMEditGUI/Component/ComponentProperties.h
@@ -241,6 +241,7 @@ private:
   QLineEdit *mpGeometryFileTextBox;
   QPushButton *mpGeometryFileBrowseButton;
   QScrollArea *mpParametersScrollArea;
+  QWidget *mpParametersScrollWidget;
   QGridLayout *mpParametersLayout;
   QLabel *mpParametersLabel;
   QList<QLabel*> mParameterLabels;

--- a/OMEdit/OMEditGUI/Component/ComponentProperties.h
+++ b/OMEdit/OMEditGUI/Component/ComponentProperties.h
@@ -240,6 +240,11 @@ private:
   Label *mpGeometryFileLabel;
   QLineEdit *mpGeometryFileTextBox;
   QPushButton *mpGeometryFileBrowseButton;
+  QScrollArea *mpParametersScrollArea;
+  QGridLayout *mpParametersLayout;
+  QLabel *mpParametersLabel;
+  QList<QLabel*> mParameterLabels;
+  QList<QLineEdit*> mParameterLineEdits;
   QPushButton *mpOkButton;
   QPushButton *mpCancelButton;
   QDialogButtonBox *mpButtonBox;

--- a/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
+++ b/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
@@ -163,21 +163,28 @@ QString MetaModelEditor::getParameterValue(QString subModelName, QString paramet
 
 void MetaModelEditor::setParameterValue(QString subModelName, QString parameterName, QString value)
 {
-    QDomNodeList subModelList = mXmlDocument.elementsByTagName("SubModel");
-    for (int i = 0 ; i < subModelList.size() ; i++) {
-      QDomElement subModelElement = subModelList.at(i).toElement();
-      if (subModelElement.attribute("Name").compare(subModelName) == 0) {
-        QDomElement parameterElement = subModelElement.firstChildElement("Parameter");
-        while(!parameterElement.isNull()) {
-            if(parameterElement.attribute("Name").compare(parameterName) == 0) {
-                parameterElement.setAttribute("Value",value);
-            }
-            parameterElement = parameterElement.nextSiblingElement("Parameter");
+  QDomNodeList subModelList = mXmlDocument.elementsByTagName("SubModel");
+  for (int i = 0 ; i < subModelList.size() ; i++) {
+    QDomElement subModelElement = subModelList.at(i).toElement();
+    if (subModelElement.attribute("Name").compare(subModelName) == 0) {
+      QDomElement parameterElement = subModelElement.firstChildElement("Parameter");
+      while(!parameterElement.isNull()) {
+        if(parameterElement.attribute("Name").compare(parameterName) == 0) {
+          parameterElement.setAttribute("Value",value);
+          setPlainText(mXmlDocument.toString());
+          return;
         }
-        setPlainText(mXmlDocument.toString());
-        return;
+        parameterElement = parameterElement.nextSiblingElement("Parameter");
       }
+      //Parameter not found, insert it
+      QDomElement parameterPoint = mXmlDocument.createElement("Parameter");
+      parameterPoint.setAttribute("Name", parameterName);
+      parameterPoint.setAttribute("Value", value);
+      subModelElement.appendChild(parameterPoint);
+      setPlainText(mXmlDocument.toString());
+      return;
     }
+  }
 }
 
 /*!

--- a/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
+++ b/OMEdit/OMEditGUI/Editors/MetaModelEditor.cpp
@@ -125,6 +125,60 @@ QDomElement MetaModelEditor::getSubModelElement(QString name)
   return QDomElement();
 }
 
+QStringList MetaModelEditor::getParameterNames(QString subModelName)
+{
+  QStringList ret;
+  QDomNodeList subModelList = mXmlDocument.elementsByTagName("SubModel");
+  for (int i = 0 ; i < subModelList.size() ; i++) {
+    QDomElement subModelElement = subModelList.at(i).toElement();
+    if(subModelElement.attribute("Name").compare(subModelName) == 0) {
+      QDomElement parameterElement = subModelElement.firstChildElement("Parameter");
+      while(!parameterElement.isNull()) {
+        ret << parameterElement.attribute("Name");
+        parameterElement = parameterElement.nextSiblingElement("Parameter");
+      }
+    }
+  }
+  return ret;
+}
+
+QString MetaModelEditor::getParameterValue(QString subModelName, QString parameterName)
+{
+  QDomNodeList subModelList = mXmlDocument.elementsByTagName("SubModel");
+  for (int i = 0 ; i < subModelList.size() ; i++) {
+    QDomElement subModelElement = subModelList.at(i).toElement();
+    if(subModelElement.attribute("Name").compare(subModelName) == 0) {
+      QDomElement parameterElement = subModelElement.firstChildElement("Parameter");
+      while(!parameterElement.isNull()) {
+        if(parameterElement.attribute("Name").compare(parameterName) == 0) {
+          return parameterElement.attribute("Value");
+        }
+        parameterElement = parameterElement.nextSiblingElement("Parameter");
+      }
+    }
+  }
+  return "";      //Should never happen
+}
+
+void MetaModelEditor::setParameterValue(QString subModelName, QString parameterName, QString value)
+{
+    QDomNodeList subModelList = mXmlDocument.elementsByTagName("SubModel");
+    for (int i = 0 ; i < subModelList.size() ; i++) {
+      QDomElement subModelElement = subModelList.at(i).toElement();
+      if (subModelElement.attribute("Name").compare(subModelName) == 0) {
+        QDomElement parameterElement = subModelElement.firstChildElement("Parameter");
+        while(!parameterElement.isNull()) {
+            if(parameterElement.attribute("Name").compare(parameterName) == 0) {
+                parameterElement.setAttribute("Value",value);
+            }
+            parameterElement = parameterElement.nextSiblingElement("Parameter");
+        }
+        setPlainText(mXmlDocument.toString());
+        return;
+      }
+    }
+}
+
 /*!
  * \brief MetaModelEditor::getMetaModelName
  * Gets the MetaModel name.
@@ -538,7 +592,7 @@ QString MetaModelEditor::getSimulationStopTime()
  * Adds the InterfacePoint tag to SubModel.
  * \param interfaces
  */
-void MetaModelEditor::addInterfacesData(QDomElement interfaces, QString singleModel)
+void MetaModelEditor::addInterfacesData(QDomElement interfaces, QDomElement parameters, QString singleModel)
 {
   QDomNodeList subModelList = mXmlDocument.elementsByTagName("SubModel");
   for (int i = 0 ; i < subModelList.size() ; i++) {
@@ -620,6 +674,52 @@ void MetaModelEditor::addInterfacesData(QDomElement interfaces, QString singleMo
       }
       else {
         subModelInterfaceDataElement = subModelInterfaceDataElement.nextSiblingElement("InterfacePoint");
+      }
+    }
+
+    //Add or update parameters
+    QDomElement parameterDataElement = parameters.firstChildElement();
+    while (!parameterDataElement.isNull()) {
+      subModel = subModelList.at(i).toElement();
+      if (subModel.attribute("Name").compare(parameterDataElement.attribute("model")) == 0 &&
+          (subModel.attribute("Name") == singleModel || singleModel.isEmpty())) {
+        QDomElement parameterPoint;
+        // update parameter
+        //Do nothing if parameter already exists (i.e. never overwrite values)
+        if (!existParameter(subModel.attribute("Name"), parameterDataElement)) {  // insert parameter
+          QDomElement parameterPoint = mXmlDocument.createElement("Parameter");
+          parameterPoint.setAttribute("Name", parameterDataElement.attribute("Name"));
+          parameterPoint.setAttribute("Value", parameterDataElement.attribute("DefaultValue"));
+          subModel.appendChild(parameterPoint);
+        }
+      }
+      parameterDataElement = parameterDataElement.nextSiblingElement();
+    }
+
+    //Remove all parameters in sub model that does not exist in fetched data (i.e. has been externally removed)
+    subModel = subModelList.at(i).toElement();
+    if(subModel.attribute("Name") != singleModel && !singleModel.isEmpty()){
+      continue;   //Ignore other models if single model is specified
+    }
+    pComponent = mpModelWidget->getDiagramGraphicsView()->getComponentObject(subModel.attribute("Name"));
+    QDomElement subModelParameterDataElement = subModel.firstChildElement("Parameter");
+    while (!subModelParameterDataElement.isNull()) {
+      bool parameterExists = false;
+      parameterDataElement = parameters.firstChildElement();
+      while (!parameterDataElement.isNull()) {
+        if (subModelParameterDataElement.attribute("Name") == parameterDataElement.attribute("Name") &&
+          subModel.attribute("Name") == parameterDataElement.attribute("model")) {
+          parameterExists = true;
+        }
+        parameterDataElement = parameterDataElement.nextSiblingElement();
+      }
+      if (!parameterExists) {
+        QDomElement elementToRemove = subModelParameterDataElement;
+        subModelParameterDataElement = subModelParameterDataElement.nextSiblingElement("Parameter");
+        subModel.removeChild(elementToRemove);
+      }
+      else {
+        subModelParameterDataElement = subModelParameterDataElement.nextSiblingElement("Parameter");
       }
     }
   }
@@ -823,6 +923,26 @@ bool MetaModelEditor::existInterfacePoint(QString subModelName, QString interfac
         QDomElement interfaceElement = subModelChildren.at(j).toElement();
         if (interfaceElement.tagName().compare("InterfacePoint") == 0 &&
             interfaceElement.attribute("Name").compare(interfaceName) == 0) {
+          return true;
+        }
+      }
+      break;
+    }
+  }
+  return false;
+}
+
+bool MetaModelEditor::existParameter(QString subModelName, QDomElement parameterDataElement)
+{
+  QDomNodeList subModelList = mXmlDocument.elementsByTagName("SubModel");
+  for (int i = 0 ; i < subModelList.size() ; i++) {
+    QDomElement subModel = subModelList.at(i).toElement();
+    if (subModel.attribute("Name").compare(subModelName) == 0) {
+      QDomNodeList subModelChildren = subModel.childNodes();
+      for (int j = 0 ; j < subModelChildren.size() ; j++) {
+        QDomElement parameterElement = subModelChildren.at(j).toElement();
+        if (parameterElement.tagName().compare("Parameter") == 0 &&
+            parameterElement.attribute("Name").compare(parameterDataElement.attribute("Name")) == 0) {
           return true;
         }
       }
@@ -1184,6 +1304,7 @@ void MetaModelHighlighter::initializeSettings()
                   << "\\bSubModels\\b"
                   << "\\bSubModel\\b"
                   << "\\bInterfacePoint\\b"
+                  << "\\bParameter\\b"
                   << "\\bConnections\\b"
                   << "\\bConnection\\b"
                   << "\\bLines\\b"

--- a/OMEdit/OMEditGUI/Editors/MetaModelEditor.h
+++ b/OMEdit/OMEditGUI/Editors/MetaModelEditor.h
@@ -73,6 +73,9 @@ public:
   QDomElement getConnectionsElement();
   QDomNodeList getConnections();
   QDomElement getSubModelElement(QString name);
+  QStringList getParameterNames(QString subModelName);
+  QString getParameterValue(QString subModelName, QString parameterName);
+  void setParameterValue(QString subModelName, QString parameterName, QString value);
   void setMetaModelName(QString name);
   bool addSubModel(Component *pComponent);
   void createAnnotationElement(QDomElement subModel, QString visible, QString origin, QString extent, QString rotation);
@@ -86,7 +89,7 @@ public:
   bool isSimulationParams();
   QString getSimulationStartTime();
   QString getSimulationStopTime();
-  void addInterfacesData(QDomElement interfaces, QString singleModel=QString());
+  void addInterfacesData(QDomElement interfaces, QDomElement parameters, QString singleModel=QString());
   void addInterface(Component *pInterfaceComponent, QString subModel);
   bool interfacesAligned(QString interface1, QString interface2);
   bool deleteSubModel(QString name);
@@ -98,6 +101,7 @@ private:
   XMLDocument mXmlDocument;
 
   bool existInterfacePoint(QString subModelName, QString interfaceName);
+  bool existParameter(QString subModelName, QDomElement parameterDataElement);
   bool getPositionAndRotationVectors(QString interfacePoint, QGenericMatrix<3,1,double> &CG_X_PHI_CG, QGenericMatrix<3,1,double> &X_C_PHI_X,
                                      QGenericMatrix<3,1,double> &CG_X_R_CG, QGenericMatrix<3,1,double> &X_C_R_X);
   bool fuzzyCompare(double p1, double p2);

--- a/OMEdit/OMEditGUI/Editors/MetaModelEditor.h
+++ b/OMEdit/OMEditGUI/Editors/MetaModelEditor.h
@@ -104,6 +104,7 @@ private:
   QGenericMatrix<3, 1, double> getRotationVector(QGenericMatrix<3, 3, double> R);
 private slots:
   virtual void showContextMenu(QPoint point);
+  void updateAllOrientations();
 public slots:
   void setPlainText(const QString &text);
   virtual void contentsHasChanged(int position, int charsRemoved, int charsAdded);

--- a/OMEdit/OMEditGUI/MainWindow.cpp
+++ b/OMEdit/OMEditGUI/MainWindow.cpp
@@ -2278,17 +2278,24 @@ void MainWindow::readInterfaceData(LibraryTreeItem *pLibraryTreeItem)
                           GUIMessages::getMessage(GUIMessages::ERROR_OPENING_FILE).arg("interfaceData.xml")
                           .arg(file.errorString()), Helper::ok);
   } else {
-    QDomDocument interfaceData;
-    interfaceData.setContent(&file);
+    QDomDocument modelDataDocument;
+    modelDataDocument.setContent(&file);
     file.close();
     // Get the interfaces element
-    QDomElement interfaces = interfaceData.documentElement();
+    QDomElement modelData, interfaces,parameters;
+    modelData = modelDataDocument.documentElement();
+    interfaces = modelData.firstChildElement("Interfaces");
+    parameters = modelData.firstChildElement("Parameters");
+    if(interfaces.isNull() && parameters.isNull()) {
+        interfaces = modelDataDocument.documentElement();   //Backwards compatibility, remove later /Robert
+    }
+
     // if we don't have ModelWidget then show it.
     if (!pLibraryTreeItem->getModelWidget()) {
       mpLibraryWidget->getLibraryTreeModel()->showModelWidget(pLibraryTreeItem);
     }
     MetaModelEditor *pMetaModelEditor = dynamic_cast<MetaModelEditor*>(pLibraryTreeItem->getModelWidget()->getEditor());
-    pMetaModelEditor->addInterfacesData(interfaces, singleModel);
+    pMetaModelEditor->addInterfacesData(interfaces, parameters, singleModel);
     pLibraryTreeItem->getModelWidget()->updateModelText();
   }
 }

--- a/OMEdit/OMEditGUI/Modeling/Commands.h
+++ b/OMEdit/OMEditGUI/Modeling/Commands.h
@@ -145,6 +145,8 @@ private:
   GraphicsView *mpIconGraphicsView;
   GraphicsView *mpDiagramGraphicsView;
   GraphicsView *mpGraphicsView;
+  QStringList mParameterNames;
+  QStringList mParameterValues;
 };
 
 class AddConnectionCommand : public QUndoCommand
@@ -244,13 +246,17 @@ class UpdateSubModelAttributesCommand : public QUndoCommand
 {
 public:
   UpdateSubModelAttributesCommand(Component *pComponent, const ComponentInfo &oldComponentInfo, const ComponentInfo &newComponentInfo,
-                                  QUndoCommand *pParent = 0);
+                                  QStringList &parameterNames, QStringList &oldParameterValues,
+                                  QStringList &newParameterValues, QUndoCommand *pParent = 0);
   void redo();
   void undo();
 private:
   Component *mpComponent;
   ComponentInfo mOldComponentInfo;
   ComponentInfo mNewComponentInfo;
+  QStringList mParameterNames;
+  QStringList mOldParameterValues;
+  QStringList mNewParameterValues;
 };
 
 class UpdateSimulationParamsCommand : public QUndoCommand

--- a/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
@@ -5037,8 +5037,11 @@ void ModelWidgetContainer::updateThreeDViewer(ModelWidget *pModelWidget)
     QString visualXMLFileName = QString("%1/%2_visual.xml").arg(Utilities::tempDirectory()).arg(fileName);
     // write dummy csv file and visualization file
     if (pModelWidget->writeCoSimulationResultFile(resultFileName) && pModelWidget->writeVisualXMLFile(visualXMLFileName, true)) {
+      MainWindow::instance()->getThreeDViewer()->stashView();
       MainWindow::instance()->getThreeDViewerDockWidget()->show();
-      MainWindow::instance()->getThreeDViewer()->openAnimationFile(resultFileName);
+      MainWindow::instance()->getThreeDViewer()->clearView();
+      MainWindow::instance()->getThreeDViewer()->openAnimationFile(resultFileName,true);
+      MainWindow::instance()->getThreeDViewer()->popView();
     } else {
       MainWindow::instance()->getThreeDViewer()->clearView();
     }

--- a/OMEdit/OMEditGUI/Resources/XMLSchema/tlmModelDescription.xsd
+++ b/OMEdit/OMEditGUI/Resources/XMLSchema/tlmModelDescription.xsd
@@ -110,6 +110,15 @@
             <xs:attribute name="Angle321" type="xs:string" use="optional"/>
           </xs:complexType>
         </xs:element>
+        <xs:element name="Parameter" minOccurs="0" maxOccurs="unbounded">
+          <xs:annotation>
+            <xs:documentation>TLM parameter for SubModel</xs:documentation>
+          </xs:annotation>
+          <xs:complexType>
+            <xs:attribute name="Name" type="xs:string" use="required"/>
+            <xs:attribute name="Value" type="xs:string" use="required"/>
+          </xs:complexType>
+        </xs:element>
       </xs:sequence>
       <xs:attribute name="Name" type="xs:string" use="required"/>
       <xs:attribute name="StartCommand" type="xs:string" use="required"/>


### PR DESCRIPTION
Parameters are fetched from external models just like interfaces. They can then be edited from the SubModel Attributes dialog. A scrollbar will appear if there are too many parameters.

(requires latest version of TLMPlugin)