### PR TITLE
Fixes to camera position and updating of 3D viewer

### DIFF
--- a/OMEdit/OMEditGUI/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditGUI/Animation/AbstractAnimationWindow.cpp
@@ -72,7 +72,8 @@ AbstractAnimationWindow::AbstractAnimationWindow(QWidget *pParent)
     mpSpeedComboBox(nullptr),
     mpPerspectiveDropDownBox(nullptr),
     mpRotateCameraLeftAction(nullptr),
-    mpRotateCameraRightAction(nullptr)
+    mpRotateCameraRightAction(nullptr),
+    mCameraInitialized(false)
 {
   // to distinguish this widget as a subwindow among the plotwindows
   setObjectName(QString("animationWidget"));
@@ -99,7 +100,7 @@ AbstractAnimationWindow::AbstractAnimationWindow(QWidget *pParent)
  * \brief AbstractAnimationWindow::openAnimationFile
  * \param fileName
  */
-void AbstractAnimationWindow::openAnimationFile(QString fileName)
+void AbstractAnimationWindow::openAnimationFile(QString fileName, bool stashCamera)
 {
   std::string file = fileName.toStdString();
   if (file.compare("")) {
@@ -128,6 +129,11 @@ void AbstractAnimationWindow::openAnimationFile(QString fileName)
       } else {
         mpPerspectiveDropDownBox->setCurrentIndex(1);
         cameraPositionSide();
+      }
+
+      if(stashCamera && !mCameraInitialized) {         // mCameraInitialized is used to make sure the view is never stashed
+        mCameraInitialized = true;      // before the camera is initialized the first time
+        stashView();
       }
     }
   }
@@ -212,6 +218,19 @@ void AbstractAnimationWindow::clearView()
     mpViewerWidget->getSceneView()->setSceneData(0);
     mpViewerWidget->update();
   }
+}
+
+void AbstractAnimationWindow::stashView()
+{
+  if(!mCameraInitialized) return;
+  mStashedViewMatrix = mpViewerWidget->getSceneView()->getCameraManipulator()->getMatrix();
+}
+
+void AbstractAnimationWindow::popView()
+{
+    if(!mCameraInitialized) return;
+    mpViewerWidget->getSceneView()->getCameraManipulator()->setByMatrix(mStashedViewMatrix);
+    mpViewerWidget->update();
 }
 
 /*!

--- a/OMEdit/OMEditGUI/Animation/AbstractAnimationWindow.h
+++ b/OMEdit/OMEditGUI/Animation/AbstractAnimationWindow.h
@@ -52,9 +52,11 @@ class AbstractAnimationWindow : public QMainWindow
   Q_OBJECT
 public:
   AbstractAnimationWindow(QWidget *pParent);
-  void openAnimationFile(QString fileName);
+  void openAnimationFile(QString fileName, bool stashCamera=false);
   virtual void createActions();
   void clearView();
+  void stashView();
+  void popView();
 private:
   bool loadVisualization();
 protected:
@@ -78,6 +80,8 @@ protected:
   QComboBox *mpPerspectiveDropDownBox;
   QAction *mpRotateCameraLeftAction;
   QAction *mpRotateCameraRightAction;
+  osg::Matrixd mStashedViewMatrix;
+  bool mCameraInitialized;
 
   void resetCamera();
   void cameraPositionIsometric();

--- a/OMEdit/OMEditGUI/Editors/MetaModelEditor.h
+++ b/OMEdit/OMEditGUI/Editors/MetaModelEditor.h
@@ -104,6 +104,7 @@ private:
   QGenericMatrix<3, 1, double> getRotationVector(QGenericMatrix<3, 3, double> R);
 private slots:
   virtual void showContextMenu(QPoint point);
+  void updateAllOrientations();
 public slots:
   void setPlainText(const QString &text);
   virtual void contentsHasChanged(int position, int charsRemoved, int charsAdded);

--- a/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
+++ b/OMEdit/OMEditGUI/Modeling/ModelWidgetContainer.cpp
@@ -5037,8 +5037,11 @@ void ModelWidgetContainer::updateThreeDViewer(ModelWidget *pModelWidget)
     QString visualXMLFileName = QString("%1/%2_visual.xml").arg(Utilities::tempDirectory()).arg(fileName);
     // write dummy csv file and visualization file
     if (pModelWidget->writeCoSimulationResultFile(resultFileName) && pModelWidget->writeVisualXMLFile(visualXMLFileName, true)) {
+      MainWindow::instance()->getThreeDViewer()->stashView();
       MainWindow::instance()->getThreeDViewerDockWidget()->show();
-      MainWindow::instance()->getThreeDViewer()->openAnimationFile(resultFileName);
+      MainWindow::instance()->getThreeDViewer()->clearView();
+      MainWindow::instance()->getThreeDViewer()->openAnimationFile(resultFileName,true);
+      MainWindow::instance()->getThreeDViewer()->popView();
     } else {
       MainWindow::instance()->getThreeDViewer()->clearView();
     }


### PR DESCRIPTION
This makes sure that the camera perspective/zoom is kept when the 3D viewer is updated.

I also made sure the view is updated when aligning interfaces and when switching between text and diagram view.