### PR TITLE
Create QTranslator instances on heap (fixes #4311)

### DIFF
--- a/OMEdit/OMEditGUI/OMEditApplication.cpp
+++ b/OMEdit/OMEditGUI/OMEditApplication.cpp
@@ -89,17 +89,17 @@ OMEditApplication::OMEditApplication(int &argc, char **argv)
 
   QString translationDirectory = omhome + QString("/share/omedit/nls");
   // install Qt's default translations
-  QTranslator qtTranslator;
+  QTranslator *qtTranslator = new QTranslator(this);
 #ifdef Q_OS_WIN
-  qtTranslator.load("qt_" + locale, translationDirectory);
+  qtTranslator->load("qt_" + locale, translationDirectory);
 #else
-  qtTranslator.load("qt_" + locale, QLibraryInfo::location(QLibraryInfo::TranslationsPath));
+  qtTranslator->load("qt_" + locale, QLibraryInfo::location(QLibraryInfo::TranslationsPath));
 #endif
-  installTranslator(&qtTranslator);
+  installTranslator(qtTranslator);
   // install application translations
-  QTranslator translator;
-  translator.load("OMEdit_" + locale, translationDirectory);
-  installTranslator(&translator);
+  QTranslator *translator = new QTranslator(this);
+  translator->load("OMEdit_" + locale, translationDirectory);
+  installTranslator(translator);
   // Splash Screen
   QPixmap pixmap(":/Resources/icons/omedit_splashscreen.png");
   SplashScreen *pSplashScreen = SplashScreen::instance();


### PR DESCRIPTION
Inside of OMEditApplication's constructor two QTranslator objects will be created on the stack. They get out of scope and will be destroyed after the constructor is finished. This causes OMEdit to crash immediately after start with Qt 5.8

This should also affect Qt versions prior to 5.8 if OMEditApplication's translate() method is called later again, e.g. after creating new widgets.

As solution the QTranslation instances will be created on heap with OMEditApplication as parent, so that the objects will be automatically detroyed if the application is closed. 

This fixes [ticket #4311](https://trac.openmodelica.org/OpenModelica/ticket/4311)