### PR TITLE
fix centos compilation and adapt to clang on msys2/mingw

### DIFF
--- a/Makefile.omdev.mingw
+++ b/Makefile.omdev.mingw
@@ -11,7 +11,10 @@ all: omedit
 
 CC = gcc
 CXX = g++
-CFLAGS = -O2 -falign-functions -fstack-protector-all
+
+ifeq (gcc,$(findstring gcc,$(CC)))
+	override CFLAGS +=-falign-functions -fstack-protector-all
+endif
 AR = ar
 CMAKE = $(OMDEVMSYS)/bin/cmake/bin/cmake
 CMAKE_TARGET = "MSYS Makefiles"
@@ -33,7 +36,7 @@ clean:
 qjson-build:
 	test -d qjson
 	mkdir -p qjson/build/include/qjson
-	(cd qjson/build && test -f Makefile || CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" $(CMAKE) -D CMAKE_AR:String="$(AR)" .. -DQT4_BUILD:Boolean=OFF -G $(CMAKE_TARGET) -DCMAKE_INSTALL_PREFIX:PATH=`pwd`)
+	(cd qjson/build && test -f Makefile || CC="$(CC)" CXX="$(CXX)" CFLAGS="$(CFLAGS)" CPPFLAGS="$(CPPFLAGS)" $(CMAKE) -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -D CMAKE_AR:String="$(AR)" .. -DQT4_BUILD:Boolean=OFF -G $(CMAKE_TARGET) -DCMAKE_INSTALL_PREFIX:PATH=`pwd`)
 	test -f qjson/build/lib/libqjson$(SHREXT) || $(MAKE) -C qjson/build install
 	cp -a qjson/build/lib/libqjson*$(SHREXT)* $(OMBUILDDIR)/lib/omc/
 	cp -a qjson/build/bin/libqjson*$(SHREXT)* $(OMBUILDDIR)/lib/omc/

--- a/OMEdit/OMEditGUI/CrashReport/backtrace.h
+++ b/OMEdit/OMEditGUI/CrashReport/backtrace.h
@@ -25,7 +25,7 @@ extern "C" {
 #include <windows.h>
 #include <excpt.h>
 #include <imagehlp.h>
-#if defined(__MINGW32__) && (GCC_VERSION > 40900)
+#if defined(__MINGW32__) && ((GCC_VERSION > 40900) || defined(__clang__))
 #define PACKAGE OMEdit
 #include <binutils/bfd.h>
 #else

--- a/qjson/CMakeLists.txt
+++ b/qjson/CMakeLists.txt
@@ -57,6 +57,16 @@ IF (Qt5Core_FOUND)
   # As moc files are generated in the binary dir, tell CMake
   # to always look for includes there:
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+  # find "-std=" in the flags, some Qt5 cmake configs do not set it (centos el7)
+  string(FIND ${CMAKE_CXX_FLAGS} "-std" FLAG_INDEX)
+  # check if we found it
+  if (FLAG_INDEX GREATER 0)
+   message(STATUS "We have -std=something")
+  else()
+   message(STATUS "Qt5 doesn't set std=c++11, add it")
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  endif()
 ELSE()
   MESSAGE ("Qt5 not found, searching for Qt4")
   # Find Qt4


### PR DESCRIPTION
- add -std=c++11 if Qt5 cmake macro doesn't do it
- check for clang on mingw in backtrace.h