### PR TITLE
Allow setting the visualization on repeat

### DIFF
--- a/OMEdit/OMEditGUI/Animation/AbstractAnimationWindow.cpp
+++ b/OMEdit/OMEditGUI/Animation/AbstractAnimationWindow.cpp
@@ -66,6 +66,7 @@ AbstractAnimationWindow::AbstractAnimationWindow(QWidget *pParent)
     mpAnimationInitializeAction(nullptr),
     mpAnimationPlayAction(nullptr),
     mpAnimationPauseAction(nullptr),
+    mpAnimationRepeatAction(nullptr),
     mpAnimationSlider(nullptr),
     mpAnimationTimeLabel(nullptr),
     mpTimeTextBox(nullptr),
@@ -116,6 +117,7 @@ void AbstractAnimationWindow::openAnimationFile(QString fileName, bool stashCame
       mpAnimationInitializeAction->setEnabled(true);
       mpAnimationPlayAction->setEnabled(true);
       mpAnimationPauseAction->setEnabled(true);
+      mpAnimationRepeatAction->setEnabled(true);
       mpAnimationSlider->setEnabled(true);
       bool state = mpAnimationSlider->blockSignals(true);
       mpAnimationSlider->setValue(0);
@@ -168,6 +170,12 @@ void AbstractAnimationWindow::createActions()
   mpAnimationPauseAction->setStatusTip(Helper::animationPauseTip);
   mpAnimationPauseAction->setEnabled(false);
   connect(mpAnimationPauseAction, SIGNAL(triggered()),this, SLOT(pauseSlotFunction()));
+  // animation repeat action
+  mpAnimationRepeatAction = new QAction(QIcon(":/Resources/icons/refresh.svg"), Helper::animationRepeat, this);
+  mpAnimationRepeatAction->setStatusTip(Helper::animationRepeatTip);
+  mpAnimationRepeatAction->setEnabled(false);
+  mpAnimationRepeatAction->setCheckable(true);
+  connect(mpAnimationRepeatAction, SIGNAL(triggered(bool)),this, SLOT(repeatSlotFunciton(bool)));
   // animation slide
   mpAnimationSlider = new QSlider(Qt::Horizontal);
   mpAnimationSlider->setMinimum(0);
@@ -601,6 +609,16 @@ void AbstractAnimationWindow::playSlotFunction()
 void AbstractAnimationWindow::pauseSlotFunction()
 {
   mpVisualizer->getTimeManager()->setPause(true);
+}
+
+/*!
+ * \brief AbstractAnimationWindow::repeatSlotFunciton
+ * Slot function for the repeat button
+ * \param checked
+ */
+void AbstractAnimationWindow::repeatSlotFunciton(bool checked)
+{
+  mpVisualizer->getTimeManager()->setRepeat(checked);
 }
 
 /*!

--- a/OMEdit/OMEditGUI/Animation/AbstractAnimationWindow.h
+++ b/OMEdit/OMEditGUI/Animation/AbstractAnimationWindow.h
@@ -93,6 +93,7 @@ protected:
   QAction *mpAnimationPlayAction;
   QAction *mpAnimationPauseAction;
   QAction *mpInteractiveControlAction;
+  QAction *mpAnimationRepeatAction;
   QSlider* mpAnimationSlider;
   Label *mpAnimationTimeLabel;
   QLineEdit *mpTimeTextBox;
@@ -121,6 +122,7 @@ public slots:
   void initSlotFunction();
   void playSlotFunction();
   void pauseSlotFunction();
+  void repeatSlotFunciton(bool checked);
   void sliderSetTimeSlotFunction(int value);
   void jumpToTimeSlotFunction();
   void setSpeedSlotFunction();

--- a/OMEdit/OMEditGUI/Animation/AnimationWindow.cpp
+++ b/OMEdit/OMEditGUI/Animation/AnimationWindow.cpp
@@ -76,6 +76,8 @@ void AnimationWindow::createActions()
   mpAnimationToolBar->addSeparator();
   mpAnimationToolBar->addAction(mpAnimationPauseAction);
   mpAnimationToolBar->addSeparator();
+  mpAnimationToolBar->addAction(mpAnimationRepeatAction);
+  mpAnimationToolBar->addSeparator();
   mpAnimationToolBar->addWidget(mpAnimationSlider);
   mpAnimationToolBar->addSeparator();
   mpAnimationToolBar->addWidget(mpAnimationTimeLabel);

--- a/OMEdit/OMEditGUI/Animation/TimeManager.cpp
+++ b/OMEdit/OMEditGUI/Animation/TimeManager.cpp
@@ -44,6 +44,7 @@ TimeManager::TimeManager(const double simTime, const double realTime, const doub
     _startTime(startTime),
     _endTime(endTime),
     _pause(true),
+    _repeat(false),
     mSpeedUp(1.0)
 {
   mpUpdateSceneTimer = new QTimer;
@@ -139,6 +140,16 @@ void TimeManager::setPause(const bool status)
   } else {
     mpUpdateSceneTimer->start();
   }
+}
+
+bool TimeManager::canRepeat() const
+{
+  return _repeat;
+}
+
+void TimeManager::setRepeat(const bool repeat)
+{
+  _repeat = repeat;
 }
 
 void TimeManager::setSpeedUp(double value)

--- a/OMEdit/OMEditGUI/Animation/TimeManager.h
+++ b/OMEdit/OMEditGUI/Animation/TimeManager.h
@@ -86,6 +86,8 @@ class TimeManager
   bool isPaused() const;
   /*! \brief Sets pause status to new value. */
   void setPause(const bool status);
+  bool canRepeat() const;
+  void setRepeat(const bool repeat);
   int getTimeFraction();
   void setSpeedUp(double value);
   double getSpeedUp();
@@ -108,6 +110,8 @@ class TimeManager
   double _endTime;
   //! This variable indicates if the simulation/visualization currently pauses.
   bool _pause;
+  //! This variable indicates if the simulation/visualization can repeat.
+  bool _repeat;
   double mSpeedUp;
   rtclock_t _visualTimer;
   QTimer *mpUpdateSceneTimer;

--- a/OMEdit/OMEditGUI/Animation/Visualizer.cpp
+++ b/OMEdit/OMEditGUI/Animation/Visualizer.cpp
@@ -320,7 +320,6 @@ void VisualizerAbstract::modifyShape(std::string shapeName)
   shape->setStateSetAction(stateSetAction::update);
 }
 
-
 void VisualizerAbstract::sceneUpdate()
 {
   //measure realtime
@@ -330,7 +329,12 @@ void VisualizerAbstract::sceneUpdate()
     updateScene(mpTimeManager->getVisTime());
     //finish animation with pause when endtime is reached
     if (mpTimeManager->getVisTime() >= mpTimeManager->getEndTime()) {
-      mpTimeManager->setPause(true);
+      if (mpTimeManager->canRepeat()) {
+        initVisualization();
+        mpTimeManager->setPause(false);
+      } else {
+        mpTimeManager->setPause(true);
+      }
     } else { // get the new visualization time
       double newTime = mpTimeManager->getVisTime() + (mpTimeManager->getHVisual()*mpTimeManager->getSpeedUp());
       if (newTime <= mpTimeManager->getEndTime()) {

--- a/OMEdit/OMEditGUI/Util/Helper.cpp
+++ b/OMEdit/OMEditGUI/Util/Helper.cpp
@@ -354,6 +354,8 @@ QString Helper::animationPlay;
 QString Helper::animationPlayTip;
 QString Helper::animationPause;
 QString Helper::animationPauseTip;
+QString Helper::animationRepeat;
+QString Helper::animationRepeatTip;
 QString Helper::simulationParams;
 QString Helper::simulationParamsTip;
 QString Helper::newModel;
@@ -641,6 +643,8 @@ void Helper::initHelperVariables()
   Helper::animationInitializeTip = tr("Initialize the animation scene");
   Helper::animationPlay = tr("Play");
   Helper::animationPlayTip = tr("Play the animation");
+  Helper::animationRepeat = tr("Repeat");
+  Helper::animationRepeatTip = tr("Repeat the animation");
   Helper::animationPause = tr("Pause");
   Helper::animationPauseTip = tr("Pause the animation");
   Helper::simulationParams = tr("Simulation Parameters");

--- a/OMEdit/OMEditGUI/Util/Helper.h
+++ b/OMEdit/OMEditGUI/Util/Helper.h
@@ -356,6 +356,8 @@ public:
   static QString animationPlayTip;
   static QString animationPause;
   static QString animationPauseTip;
+  static QString animationRepeat;
+  static QString animationRepeatTip;
   static QString simulationParams;
   static QString simulationParamsTip;
   static QString newModel;


### PR DESCRIPTION
@vwaurich Can you test this. I added the feature to set the visualization on repeat but after few cycles the visualization becomes slow. The OMEdit process starts consuming more and more memory. It seems like we have some memory leaks. Is it possible to cache the values after first cycle and then reuse them from the local data structure. I personally think that the mat/csv readers are allocating memory each time we ask for a value.